### PR TITLE
Enhance hero background effects and smooth scrolling

### DIFF
--- a/src/layouts/AppShell.astro
+++ b/src/layouts/AppShell.astro
@@ -3,6 +3,7 @@ import "../styles/global.css";
 import CommandPalette from "../components/CommandPalette";
 import ThemeToggle from "../components/ThemeToggle";
 import SearchBox from "../components/SearchBox.astro";
+import lenisScript from "../scripts/lenis.ts?url";
 
 const navLinks = [
   { href: "/", label: "Home" },
@@ -105,30 +106,6 @@ const navLinks = [
       attachCommandButton();
       document.addEventListener('astro:page-load', attachCommandButton);
     </script>
-    <script is:inline type="module">
-      import Lenis from "lenis";
-
-      const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-      if (!prefersReduced) {
-        let lenis = new Lenis({
-          smoothWheel: true,
-          lerp: 0.12,
-          duration: 1.2
-        });
-
-        function raf(time) {
-          lenis.raf(time);
-          requestAnimationFrame(raf);
-        }
-
-        requestAnimationFrame(raf);
-
-        document.addEventListener('astro:after-swap', () => {
-          lenis?.destroy();
-          lenis = new Lenis({ smoothWheel: true, lerp: 0.12, duration: 1.2 });
-          requestAnimationFrame(raf);
-        });
-      }
-    </script>
+    <script type="module" src={lenisScript}></script>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,51 +23,75 @@ const latestProjects = projectEntries.slice(0, 3);
     />
   </fragment>
   <section class="grid gap-16">
-    <div class="grid gap-10 rounded-[32px] border border-border/60 bg-surface/60 p-10 shadow-soft md:grid-cols-[1.2fr,1fr]">
-      <div class="space-y-6">
-        <p class="text-sm uppercase tracking-[0.3em] text-text-muted">Hello, I’m Ashton</p>
-        <h1 class="text-4xl font-semibold leading-tight md:text-5xl">
-          I design and build delightful software, orchestration systems, and creative tools.
-        </h1>
-        <p class="max-w-prose text-lg text-text-secondary">
-          Currently shipping at the intersection of product, engineering, and storytelling. I craft
-          experiences that feel alive—fast, tactile, and welcoming. This site documents the work,
-          experiments, and ideas along the way.
-        </p>
-        <div class="flex flex-wrap gap-3 text-sm">
-          <a
-            href="/projects"
-            class="rounded-full border border-border bg-background px-5 py-2 font-medium text-text-primary transition hover:border-accent hover:bg-accent-soft hover:text-accent"
-            data-astro-transition="animate"
-          >
-            Explore projects
-          </a>
-          <a
-            href="/writing"
-            class="rounded-full border border-border/70 px-5 py-2 font-medium text-text-secondary transition hover:border-accent hover:text-text-primary"
-            data-astro-transition="animate"
-          >
-            Read the latest writing
-          </a>
-        </div>
+    <div class="with-grain relative overflow-hidden rounded-[32px] border border-border/60 bg-surface/60 p-10 shadow-soft">
+      <div aria-hidden="true" class="pointer-events-none absolute inset-0 overflow-hidden">
+        <div
+          class="bg-radial absolute inset-0"
+          style="
+            --radial-position-x: 20%;
+            --radial-position-y: 25%;
+            --radial-stops: color-mix(in srgb, var(--accent) 28%, transparent) 0%, transparent 70%;
+          "
+        ></div>
+        <div
+          class="bg-conic absolute inset-[10%] mix-blend-screen opacity-70"
+          style="
+            --conic-angle: -140deg;
+            --conic-position-x: 72%;
+            --conic-position-y: 38%;
+            --conic-stops: transparent 0deg,
+              color-mix(in srgb, var(--accent-strong, var(--accent)) 55%, transparent) 120deg,
+              transparent 320deg;
+          "
+        ></div>
       </div>
-      <div class="flex h-full flex-col justify-between gap-6 rounded-3xl border border-border/40 bg-background/70 p-6 text-sm text-text-secondary shadow-ring">
-        <div>
-          <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">Now</h2>
-          <p class="mt-3 leading-relaxed">
-            I’m deep in prototyping mode—building research tools for independent teams, exploring
-            spatial interfaces, and writing about sustainable pace.
+      <div class="relative grid gap-10 md:grid-cols-[1.2fr,1fr]">
+        <div class="space-y-6">
+          <p class="text-sm uppercase tracking-[0.3em] text-text-muted">Hello, I’m Ashton</p>
+          <h1 class="text-4xl font-semibold leading-tight md:text-5xl" data-hero-animate>
+            I design and build delightful software, orchestration systems, and creative tools.
+          </h1>
+          <p class="max-w-prose text-lg text-text-secondary">
+            Currently shipping at the intersection of product, engineering, and storytelling. I craft
+            experiences that feel alive—fast, tactile, and welcoming. This site documents the work,
+            experiments, and ideas along the way.
           </p>
+          <div class="flex flex-wrap gap-3 text-sm" data-hero-animate>
+            <a
+              href="/projects"
+              class="rounded-full border border-border bg-background px-5 py-2 font-medium text-text-primary transition hover:border-accent hover:bg-accent-soft hover:text-accent"
+              data-astro-transition="animate"
+            >
+              <span class="text-reveal" style="--text-reveal-base: var(--text-1)">Explore projects</span>
+            </a>
+            <a
+              href="/writing"
+              class="rounded-full border border-border/70 px-5 py-2 font-medium text-text-secondary transition hover:border-accent hover:text-text-primary"
+              data-astro-transition="animate"
+            >
+              Read the latest writing
+            </a>
+          </div>
         </div>
-        <a
-          href="/now"
-          class="inline-flex items-center gap-2 self-start rounded-full bg-accent text-sm font-semibold text-text-inverted transition hover:bg-accent-strong"
-          data-astro-transition="animate"
-        >
-          <span class="px-4 py-2">Read the full now page</span>
-        </a>
+        <div class="flex h-full flex-col justify-between gap-6 rounded-3xl border border-border/40 bg-background/70 p-6 text-sm text-text-secondary shadow-ring">
+          <div>
+            <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-text-muted">Now</h2>
+            <p class="mt-3 leading-relaxed">
+              I’m deep in prototyping mode—building research tools for independent teams, exploring
+              spatial interfaces, and writing about sustainable pace.
+            </p>
+          </div>
+          <a
+            href="/now"
+            class="inline-flex items-center gap-2 self-start rounded-full bg-accent text-sm font-semibold text-text-inverted transition hover:bg-accent-strong"
+            data-astro-transition="animate"
+          >
+            <span class="px-4 py-2">Read the full now page</span>
+          </a>
+        </div>
       </div>
     </div>
+
 
     <section class="grid gap-12 md:grid-cols-[2fr,1.2fr]">
       <div class="space-y-6">
@@ -149,4 +173,57 @@ const latestProjects = projectEntries.slice(0, 3);
       </div>
     </section>
   </section>
+  <script type="module" is:inline>
+    import { animate, stagger } from "motion";
+
+    const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)");
+    let hasPlayed = false;
+
+    const playHeroAnimation = () => {
+      if (prefersReduced.matches || hasPlayed) return;
+      const targets = Array.from(document.querySelectorAll("[data-hero-animate]"));
+      if (!targets.length) return;
+
+      animate(
+        targets,
+        { opacity: [0, 1], transform: ["translateY(24px)", "translateY(0)"] },
+        {
+          duration: 0.9,
+          delay: stagger(0.12),
+          easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+          fill: "both"
+        }
+      );
+
+      hasPlayed = true;
+    };
+
+    const scheduleAnimation = () => {
+      hasPlayed = false;
+      if (prefersReduced.matches) return;
+      requestAnimationFrame(() => playHeroAnimation());
+    };
+
+    if (document.readyState !== "loading") {
+      scheduleAnimation();
+    } else {
+      document.addEventListener(
+        "DOMContentLoaded",
+        () => {
+          scheduleAnimation();
+        },
+        { once: true }
+      );
+    }
+
+    document.addEventListener("astro:after-swap", () => {
+      scheduleAnimation();
+    });
+
+    prefersReduced.addEventListener("change", (event) => {
+      if (!event.matches) {
+        scheduleAnimation();
+      }
+    });
+  </script>
 </AppShell>

--- a/src/scripts/lenis.ts
+++ b/src/scripts/lenis.ts
@@ -1,0 +1,65 @@
+import Lenis from "lenis";
+
+const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+let lenis: Lenis | null = null;
+let rafId: number | null = null;
+
+const cancelLoop = () => {
+  if (rafId !== null) {
+    cancelAnimationFrame(rafId);
+    rafId = null;
+  }
+};
+
+const destroyLenis = () => {
+  cancelLoop();
+  lenis?.destroy();
+  lenis = null;
+};
+
+const startLoop = () => {
+  cancelLoop();
+  if (!lenis) return;
+
+  const loop = (time: number) => {
+    lenis?.raf(time);
+    rafId = requestAnimationFrame(loop);
+  };
+
+  rafId = requestAnimationFrame(loop);
+};
+
+const initLenis = () => {
+  destroyLenis();
+  if (prefersReducedMotion.matches) return;
+
+  lenis = new Lenis({
+    smoothWheel: true,
+    lerp: 0.12,
+    duration: 1.2
+  });
+
+  startLoop();
+};
+
+const setup = () => {
+  initLenis();
+};
+
+if (document.readyState === "complete") {
+  setup();
+} else {
+  window.addEventListener("load", setup, { once: true });
+}
+
+document.addEventListener("astro:after-swap", () => {
+  setup();
+});
+
+prefersReducedMotion.addEventListener("change", (event) => {
+  if (event.matches) {
+    destroyLenis();
+  } else {
+    initLenis();
+  }
+});

--- a/src/styles/effects.css
+++ b/src/styles/effects.css
@@ -1,0 +1,90 @@
+@layer base {
+  @property --reveal-progress {
+    syntax: "<angle>";
+    inherits: false;
+    initial-value: 350deg;
+  }
+}
+
+@layer utilities {
+  :root {
+    --grain-svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 120'%3E%3Cfilter id='grain'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23grain)'/%3E%3C/svg%3E");
+  }
+
+  .bg-radial {
+    --radial-shape: circle;
+    --radial-position-x: 50%;
+    --radial-position-y: 50%;
+    --radial-stops: rgba(255, 255, 255, 0.08) 0%, transparent 65%;
+    background-image: radial-gradient(
+      var(--radial-shape) at var(--radial-position-x) var(--radial-position-y),
+      var(--radial-stops)
+    );
+    background-repeat: no-repeat;
+  }
+
+  .bg-conic {
+    --conic-angle: -90deg;
+    --conic-position-x: 50%;
+    --conic-position-y: 50%;
+    --conic-stops: transparent 0deg, rgba(255, 255, 255, 0.2) 130deg, transparent 260deg;
+    background-image: conic-gradient(
+      from var(--conic-angle) at var(--conic-position-x) var(--conic-position-y),
+      var(--conic-stops)
+    );
+    background-repeat: no-repeat;
+  }
+
+  .with-grain {
+    position: relative;
+    isolation: isolate;
+  }
+
+  .with-grain::after {
+    content: "";
+    position: absolute;
+    inset: -40%;
+    background-image: var(--grain-svg);
+    background-size: 200px 200px;
+    opacity: var(--grain-opacity, 0.25);
+    mix-blend-mode: soft-light;
+    pointer-events: none;
+    filter: contrast(150%);
+  }
+
+  .text-reveal {
+    position: relative;
+    color: var(--text-reveal-base, currentColor);
+    --reveal-progress: 350deg;
+    -webkit-mask-image: conic-gradient(
+      from var(--reveal-angle, -90deg) at var(--reveal-origin-x, 50%) var(--reveal-origin-y, 50%),
+      transparent 0deg,
+      transparent var(--reveal-progress),
+      #000 var(--reveal-progress),
+      #000 360deg
+    );
+    mask-image: conic-gradient(
+      from var(--reveal-angle, -90deg) at var(--reveal-origin-x, 50%) var(--reveal-origin-y, 50%),
+      transparent 0deg,
+      transparent var(--reveal-progress),
+      #000 var(--reveal-progress),
+      #000 360deg
+    );
+    transition: --reveal-progress 450ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .text-reveal:hover,
+  .text-reveal:focus-visible {
+    --reveal-progress: 360deg;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .with-grain::after {
+      opacity: min(var(--grain-opacity, 0.25), 0.2);
+    }
+
+    .text-reveal {
+      --reveal-progress: 360deg;
+    }
+  }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,6 @@
 @import "./tokens.css";
 @import "./typography.css";
+@import "./effects.css";
 
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
## Summary
- add reusable gradient, grain, and text reveal utilities in a new effects stylesheet
- layer the home hero with radial and conic gradients, grain overlay, and Motion One entrance animation
- initialize Lenis smooth scrolling from a dedicated script and wire it through the app shell

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e193413594832ca50593ff114db22f