### PR TITLE
Define content schemas and refresh listings

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -27,6 +27,7 @@ const quickLinks: QuickLinkGroup[] = [
     items: [
       { label: "Writing", href: "/writing", description: "Essays, notes, and dispatches." },
       { label: "Projects", href: "/projects", description: "Selected work and experiments." },
+      { label: "Press", href: "/press", description: "Interviews and features from around the web." },
       { label: "Activity", href: "/activity", description: "Live feed of what I'm building." }
     ]
   },

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,32 +1,43 @@
 import { defineCollection, z } from "astro:content";
 
-const baseSchema = z.object({
-  title: z.string(),
-  date: z.coerce.date(),
-  summary: z.string().max(280),
-  tags: z.array(z.string()).default([]),
-  draft: z.boolean().default(false),
-  ogTitle: z.string().optional()
-});
-
 const writing = defineCollection({
   type: "content",
-  schema: baseSchema.extend({
-    readingTime: z.string().optional()
+  schema: z.object({
+    title: z.string(),
+    date: z.coerce.date(),
+    summary: z.string().max(280),
+    tags: z.array(z.string()).default([]),
+    draft: z.boolean().default(false),
+    ogTitle: z.string().optional()
   })
 });
 
 const projects = defineCollection({
   type: "content",
-  schema: baseSchema.extend({
-    link: z.string().url().optional(),
-    status: z.enum(["active", "archived", "upcoming"]).default("active")
+  schema: z.object({
+    title: z.string(),
+    date: z.coerce.date(),
+    summary: z.string().max(280),
+    role: z.string(),
+    stack: z.array(z.string()).default([]),
+    links: z
+      .array(
+        z.object({
+          label: z.string(),
+          url: z.string().url()
+        })
+      )
+      .default([]),
+    impact: z.array(z.string()).default([]),
+    coverEmoji: z.string().min(1).max(4)
   })
 });
 
 const press = defineCollection({
   type: "content",
-  schema: baseSchema.extend({
+  schema: z.object({
+    title: z.string(),
+    date: z.coerce.date(),
     outlet: z.string(),
     url: z.string().url()
   })

--- a/src/content/press/awesome-interview.mdx
+++ b/src/content/press/awesome-interview.mdx
@@ -1,0 +1,10 @@
+---
+title: "AwesomeFM Interview"
+date: 2023-11-02
+outlet: "AwesomeFM"
+url: "https://example.com/press/awesomefm"
+---
+
+I joined AwesomeFM to talk about the future of spatial software and the rituals that keep side
+projects shipping. We dig into how hybrid teams coordinate, why motion matters, and the value of slow
+craft alongside fast iteration.

--- a/src/content/press/creative-review-spotlight.mdx
+++ b/src/content/press/creative-review-spotlight.mdx
@@ -1,10 +1,6 @@
 ---
 title: "Creative Review Spotlight"
 date: 2024-05-18
-summary: "Featured for crafting immersive studio experiences with emerging tech."
-tags: [press, interview]
-draft: false
-ogTitle: "Creative Review Spotlight on Ashton Hawkins"
 outlet: "Creative Review"
 url: "https://example.com/press/creative-review"
 ---

--- a/src/content/projects/atlas-systems.mdx
+++ b/src/content/projects/atlas-systems.mdx
@@ -2,11 +2,15 @@
 title: "Atlas Systems"
 date: 2024-10-02
 summary: "An internal operating system for coordinating mixed-reality art installations."
-tags: [installation, realtime, research]
-draft: false
-ogTitle: "Atlas Systems — installation operations toolkit"
-link: "https://example.com/atlas"
-status: active
+role: "Product design & engineering"
+stack: [Astro, TypeScript, WebSockets, Tailwind]
+links:
+  - label: "Launch announcement"
+    url: "https://example.com/atlas"
+impact:
+  - "Coordinated multi-location show control with sub-second sync."
+  - "Reduced operator onboarding time from days to hours."
+coverEmoji: "🛰️"
 ---
 
 Atlas Systems is a custom operations platform that helps a distributed creative team prepare and run

--- a/src/content/projects/personal-site.mdx
+++ b/src/content/projects/personal-site.mdx
@@ -1,0 +1,20 @@
+---
+title: "Personal site refresh"
+date: 2024-03-07
+summary: "Reimagined my digital home with motion-rich storytelling and speedy performance."
+role: "Design, development, and content strategy"
+stack: [Astro, Tailwind, Pagefind, Motion One]
+links:
+  - label: "View the site"
+    url: "https://ashtonhawkins.com"
+  - label: "Design file"
+    url: "https://example.com/personal-site/design"
+impact:
+  - "Improved lighthouse performance scores to 99 across the board."
+  - "Doubled average session duration with clearer storytelling."
+  - "Cut publishing time from hours to minutes via structured content."
+coverEmoji: "✨"
+---
+
+This refresh focused on telling a cohesive story about hybrid product work. I composed motion studies,
+iterated on tactile theme controls, and invested in structured content so updates stay fast.

--- a/src/content/writing/hello-world.mdx
+++ b/src/content/writing/hello-world.mdx
@@ -1,0 +1,12 @@
+---
+title: "Hello, world"
+date: 2024-01-11
+summary: "A quick welcome note for friends exploring the new studio site."
+tags: [announcement, studio]
+draft: false
+ogTitle: "Hello, world — a quick welcome"
+---
+
+Welcome! This little update shares why I rebuilt the site, what I’m excited to publish, and how I
+plan to document experiments in public. Expect sketches of interface ideas, observations from
+collaborations, and lots of process notes.

--- a/src/content/writing/introducing-the-studio.mdx
+++ b/src/content/writing/introducing-the-studio.mdx
@@ -5,7 +5,6 @@ summary: "Designing a modular toolkit for running independent creative studios w
 tags: [studio, systems, tooling]
 draft: false
 ogTitle: "Introducing the studio OS"
-readingTime: "6 min read"
 ---
 
 I’ve been quietly building a collection of tools to help independent studios keep momentum without

--- a/src/layouts/AppShell.astro
+++ b/src/layouts/AppShell.astro
@@ -11,6 +11,7 @@ const navLinks = [
   { href: "/now", label: "Now" },
   { href: "/writing", label: "Writing" },
   { href: "/projects", label: "Projects" },
+  { href: "/press", label: "Press" },
   { href: "/activity", label: "Activity" }
 ];
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,7 @@ const writingEntries = (await getCollection("writing", ({ data }) => !data.draft
 );
 const latestWriting = writingEntries.slice(0, 3);
 
-const projectEntries = (await getCollection("projects", ({ data }) => !data.draft)).sort(
+const projectEntries = (await getCollection("projects")).sort(
   (a, b) => b.data.date.getTime() - a.data.date.getTime()
 );
 const latestProjects = projectEntries.slice(0, 3);
@@ -92,7 +92,6 @@ const latestProjects = projectEntries.slice(0, 3);
       </div>
     </div>
 
-
     <section class="grid gap-12 md:grid-cols-[2fr,1.2fr]">
       <div class="space-y-6">
         <header class="flex items-center justify-between">
@@ -117,13 +116,15 @@ const latestProjects = projectEntries.slice(0, 3);
                   </span>
                   <h3 class="text-xl font-semibold">{entry.data.title}</h3>
                   <p class="text-sm text-text-secondary">{entry.data.summary}</p>
-                  <div class="flex flex-wrap gap-2">
-                    {entry.data.tags.map((tag) => (
-                      <span class="rounded-full bg-accent-soft px-3 py-1 text-xs font-medium text-accent" aria-label={`Tagged ${tag}`}>
-                        #{tag}
-                      </span>
-                    ))}
-                  </div>
+                  {entry.data.tags.length ? (
+                    <div class="flex flex-wrap gap-2">
+                      {entry.data.tags.map((tag) => (
+                        <span class="rounded-full bg-accent-soft px-3 py-1 text-xs font-medium text-accent" aria-label={`Tagged ${tag}`}>
+                          #{tag}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
                 </a>
               </article>
             ))
@@ -147,22 +148,36 @@ const latestProjects = projectEntries.slice(0, 3);
               >
                 <a
                   href={`/projects/${entry.slug}`}
-                  class="grid gap-3"
+                  class="grid gap-4"
                   data-astro-transition="animate"
                 >
-                  <span class="text-xs uppercase tracking-[0.3em] text-text-muted">
-                    {dayjs(entry.data.date).format("MMM YYYY")}
-                  </span>
-                  <h3 class="text-xl font-semibold">{entry.data.title}</h3>
-                  <p class="text-sm text-text-secondary">{entry.data.summary}</p>
-                  <div class="flex items-center justify-between text-xs text-text-muted">
-                    <span class="rounded-full bg-border/40 px-3 py-1 uppercase tracking-wide text-[10px]">
-                      {entry.data.status}
+                  <div class="flex items-start justify-between">
+                    <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-border/40 text-2xl">
+                      {entry.data.coverEmoji}
                     </span>
-                    {entry.data.tags.length ? (
-                      <span>{entry.data.tags.join(" · ")}</span>
-                    ) : null}
+                    <span class="text-xs uppercase tracking-[0.3em] text-text-muted">
+                      {dayjs(entry.data.date).format("MMM YYYY")}
+                    </span>
                   </div>
+                  <div class="space-y-2">
+                    <h3 class="text-xl font-semibold">{entry.data.title}</h3>
+                    <p class="text-sm text-text-secondary">{entry.data.summary}</p>
+                    <div class="rounded-2xl bg-background/60 px-4 py-2 text-xs text-text-secondary">
+                      <span class="font-semibold text-text-primary">Role:</span> {entry.data.role}
+                    </div>
+                  </div>
+                  {entry.data.stack.length ? (
+                    <div class="flex flex-wrap gap-2 text-xs text-text-muted">
+                      {entry.data.stack.map((tech) => (
+                        <span class="rounded-full bg-border/40 px-3 py-1 font-medium">{tech}</span>
+                      ))}
+                    </div>
+                  ) : null}
+                  {entry.data.impact.length ? (
+                    <p class="text-xs text-text-muted">
+                      {entry.data.impact[0]}
+                    </p>
+                  ) : null}
                 </a>
               </article>
             ))

--- a/src/pages/press/index.astro
+++ b/src/pages/press/index.astro
@@ -1,0 +1,58 @@
+---
+import AppShell from "../../layouts/AppShell.astro";
+import { getCollection } from "astro:content";
+import dayjs from "dayjs";
+
+const press = (await getCollection("press")).sort(
+  (a, b) => b.data.date.getTime() - a.data.date.getTime()
+);
+---
+
+<AppShell>
+  <fragment slot="head">
+    <title>Press · Ashton Hawkins</title>
+    <meta
+      name="description"
+      content="Interviews, features, and mentions of Ashton Hawkins across the web."
+    />
+  </fragment>
+  <section class="space-y-10">
+    <header class="max-w-prose space-y-4">
+      <h1 class="text-4xl font-semibold text-text-primary">Press</h1>
+      <p class="text-lg text-text-secondary">
+        A collection of interviews, spotlights, and features covering the studio’s work and approach
+        to building thoughtful products.
+      </p>
+    </header>
+    <div class="grid gap-6 md:grid-cols-2">
+      {press.length ? (
+        press.map((entry) => (
+          <article class="flex h-full flex-col justify-between gap-5 rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-soft transition hover:-translate-y-1 hover:border-accent">
+            <div class="space-y-3">
+              <div class="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-text-muted">
+                <span>{entry.data.outlet}</span>
+                <span>{dayjs(entry.data.date).format("MMM D, YYYY")}</span>
+              </div>
+              <h2 class="text-2xl font-semibold text-text-primary">{entry.data.title}</h2>
+              {entry.body ? (
+                <p class="text-sm text-text-secondary">
+                  {entry.body.replace(/\n+/g, " ").trim()}
+                </p>
+              ) : null}
+            </div>
+            <a
+              href={entry.data.url}
+              target="_blank"
+              rel="noreferrer"
+              class="inline-flex items-center gap-2 self-start rounded-full bg-accent px-4 py-2 text-sm font-semibold text-text-inverted transition hover:bg-accent-strong"
+            >
+              Read feature ↗
+            </a>
+          </article>
+        ))
+      ) : (
+        <p class="text-sm text-text-muted">Press highlights are on the way.</p>
+      )}
+    </div>
+  </section>
+</AppShell>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -9,47 +9,78 @@ if (!slug) {
 }
 
 const entry = await getEntry("projects", slug);
-if (!entry || entry.data.draft) {
+if (!entry) {
   return Astro.redirect("/projects");
 }
 
 const { Content } = await entry.render();
-const { title, summary, date, status, link, tags, ogTitle } = entry.data;
+const { title, summary, date, role, stack, links, impact, coverEmoji } = entry.data;
 
 export async function getStaticPaths() {
-  const entries = await getCollection("projects", ({ data }) => !data.draft);
+  const entries = await getCollection("projects");
   return entries.map((project) => ({ params: { slug: project.slug } }));
 }
 ---
 
 <AppShell>
   <fragment slot="head">
-    <title>{ogTitle ?? title} · Projects · Ashton Hawkins</title>
+    <title>{title} · Projects · Ashton Hawkins</title>
     <meta name="description" content={summary} />
   </fragment>
   <article class="prose prose-neutral mx-auto max-w-prose text-base text-text-secondary">
-    <p class="text-xs uppercase tracking-[0.3em] text-text-muted">
-      {dayjs(date).format("MMMM YYYY")}
-    </p>
+    <div class="mb-6 flex items-center justify-between gap-4 text-sm text-text-muted">
+      <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-border/40 text-2xl">
+        {coverEmoji}
+      </span>
+      <span class="text-xs uppercase tracking-[0.3em]">{dayjs(date).format("MMMM YYYY")}</span>
+    </div>
     <h1 class="mb-4 text-4xl font-semibold text-text-primary">{title}</h1>
     <p class="text-sm text-text-muted">{summary}</p>
-    <div class="mt-4 flex flex-wrap items-center gap-3 text-xs text-text-muted">
-      <span class="rounded-full bg-border/50 px-3 py-1 uppercase tracking-wide text-[10px]">{status}</span>
-      {link ? (
-        <a
-          href={link}
-          class="inline-flex items-center gap-2 rounded-full bg-accent px-4 py-2 font-medium text-text-inverted transition hover:bg-accent-strong"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Visit project ↗
-        </a>
+    <div class="mt-6 grid gap-4 rounded-3xl border border-border/60 bg-surface/60 p-5 text-sm text-text-secondary">
+      <div>
+        <span class="text-xs font-semibold uppercase tracking-wide text-text-muted">Role</span>
+        <p class="mt-1 text-text-primary">{role}</p>
+      </div>
+      {stack.length ? (
+        <div>
+          <span class="text-xs font-semibold uppercase tracking-wide text-text-muted">Stack</span>
+          <div class="mt-2 flex flex-wrap gap-2 text-xs text-text-muted">
+            {stack.map((tech) => (
+              <span class="rounded-full bg-border/40 px-3 py-1 font-medium">{tech}</span>
+            ))}
+          </div>
+        </div>
       ) : null}
-    </div>
-    <div class="mt-6 flex flex-wrap gap-2 text-xs text-text-muted">
-      {tags.map((tag) => (
-        <span class="rounded-full bg-accent-soft px-3 py-1 font-medium text-accent">#{tag}</span>
-      ))}
+      {impact.length ? (
+        <div>
+          <span class="text-xs font-semibold uppercase tracking-wide text-text-muted">Impact</span>
+          <ul class="mt-2 space-y-2">
+            {impact.map((item) => (
+              <li class="flex items-start gap-2">
+                <span class="mt-[6px] inline-block h-1.5 w-1.5 rounded-full bg-accent"></span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {links.length ? (
+        <div>
+          <span class="text-xs font-semibold uppercase tracking-wide text-text-muted">Links</span>
+          <div class="mt-2 flex flex-wrap gap-2 text-xs">
+            {links.map((link) => (
+              <a
+                href={link.url}
+                target="_blank"
+                rel="noreferrer"
+                class="inline-flex items-center gap-2 rounded-full bg-accent px-4 py-2 font-semibold text-text-inverted transition hover:bg-accent-strong"
+              >
+                {link.label} ↗
+              </a>
+            ))}
+          </div>
+        </div>
+      ) : null}
     </div>
     <div class="mt-10 space-y-6">
       <Content />

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -3,7 +3,7 @@ import AppShell from "../../layouts/AppShell.astro";
 import { getCollection } from "astro:content";
 import dayjs from "dayjs";
 
-const projects = (await getCollection("projects", ({ data }) => !data.draft)).sort(
+const projects = (await getCollection("projects")).sort(
   (a, b) => b.data.date.getTime() - a.data.date.getTime()
 );
 ---
@@ -27,29 +27,64 @@ const projects = (await getCollection("projects", ({ data }) => !data.draft)).so
     <div class="grid gap-6 md:grid-cols-2">
       {projects.length ? (
         projects.map((entry) => (
-          <article class="flex h-full flex-col justify-between rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-soft transition hover:-translate-y-1 hover:border-accent">
-            <div class="space-y-3">
+          <article class="flex h-full flex-col gap-6 rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-soft transition hover:-translate-y-1 hover:border-accent">
+            <div class="flex items-start justify-between">
+              <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-border/40 text-2xl">
+                {entry.data.coverEmoji}
+              </span>
               <span class="text-xs uppercase tracking-[0.3em] text-text-muted">
                 {dayjs(entry.data.date).format("MMM YYYY")}
               </span>
+            </div>
+            <div class="space-y-3">
               <h2 class="text-2xl font-semibold text-text-primary">{entry.data.title}</h2>
               <p class="text-sm text-text-secondary">{entry.data.summary}</p>
+              <div class="rounded-2xl bg-background/60 px-4 py-3 text-xs text-text-secondary">
+                <span class="font-semibold text-text-primary">Role:</span> {entry.data.role}
+              </div>
             </div>
-            <div class="mt-6 flex items-center justify-between text-xs text-text-muted">
-              <span class="rounded-full bg-border/50 px-3 py-1 uppercase tracking-wide text-[10px]">
-                {entry.data.status}
-              </span>
-              {entry.data.tags.length ? (
-                <span>{entry.data.tags.join(" · ")}</span>
-              ) : null}
+            {entry.data.impact.length ? (
+              <ul class="space-y-2 text-sm text-text-secondary">
+                {entry.data.impact.map((item) => (
+                  <li class="flex items-start gap-2">
+                    <span class="mt-[6px] inline-block h-1.5 w-1.5 rounded-full bg-accent"></span>
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+            {entry.data.stack.length ? (
+              <div class="flex flex-wrap gap-2 text-xs text-text-muted">
+                {entry.data.stack.map((tech) => (
+                  <span class="rounded-full bg-border/40 px-3 py-1 font-medium">{tech}</span>
+                ))}
+              </div>
+            ) : null}
+            <div class="mt-auto flex items-center justify-between">
+              {entry.data.links.length ? (
+                <div class="flex flex-wrap gap-2 text-xs text-text-muted">
+                  {entry.data.links.map((link) => (
+                    <a
+                      href={link.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      class="rounded-full bg-background/70 px-3 py-1 font-medium text-text-secondary transition hover:text-accent"
+                    >
+                      {link.label} ↗
+                    </a>
+                  ))}
+                </div>
+              ) : (
+                <span class="text-xs text-text-muted">Documentation coming soon.</span>
+              )}
+              <a
+                href={`/projects/${entry.slug}`}
+                class="inline-flex items-center gap-2 rounded-full bg-accent px-4 py-2 text-sm font-semibold text-text-inverted transition hover:bg-accent-strong"
+                data-astro-transition="animate"
+              >
+                View project
+              </a>
             </div>
-            <a
-              href={`/projects/${entry.slug}`}
-              class="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-accent transition hover:text-accent-strong"
-              data-astro-transition="animate"
-            >
-              View case study ↗
-            </a>
           </article>
         ))
       ) : (


### PR DESCRIPTION
## Summary
- define explicit writing, projects, and press content collections with updated metadata
- add representative writing, project, and press MDX entries matching the new schemas
- refresh listing and project detail pages plus navigation to surface the richer project and press information

## Testing
- npx astro build

------
https://chatgpt.com/codex/tasks/task_e_68e19695dd54832c9aa411a990a072e3