### PR TITLE
Update Pages workflow for auto package manager detection

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,7 @@ permissions:
 concurrency:
   group: "pages"
   cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,20 +19,40 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
-      - run: node -v && npm -v && ls -la
+      - name: Detect package manager
+        id: pm
+        run: |
+          echo "PM=$(node -p \"require('./package.json').packageManager || ''\" || true)" >> $GITHUB_ENV
+          echo "HAS_PNPM=$([ -f pnpm-lock.yaml ] && echo true || echo false)" >> $GITHUB_ENV
+          echo "HAS_YARN=$([ -f yarn.lock ] && echo true || echo false)" >> $GITHUB_ENV
+          echo "HAS_NPM=$([ -f package-lock.json ] && echo true || echo false)" >> $GITHUB_ENV
       - name: Install deps
         run: |
-          if [ -f package-lock.json ]; then
-            npm ci
+          corepack enable || true
+          if [[ "$PM" == pnpm* || "$HAS_PNPM" == "true" ]]; then
+            pnpm install --frozen-lockfile || pnpm install
+          elif [[ "$PM" == yarn* || "$HAS_YARN" == "true" ]]; then
+            yarn install --frozen-lockfile || yarn install
           else
-            echo "No package-lock.json; using npm install"
-            npm install
+            if [[ "$HAS_NPM" == "true" ]]; then
+              npm ci
+            else
+              npm install
+            fi
           fi
-      - run: npm run build
+      - name: Build
+        run: |
+          if [[ "$PM" == pnpm* || "$HAS_PNPM" == "true" ]]; then
+            pnpm run build
+          elif [[ "$PM" == yarn* || "$HAS_YARN" == "true" ]]; then
+            yarn build
+          else
+            npm run build
+          fi
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
+
   deploy:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- replace the Pages workflow with a version that auto-detects npm, pnpm, or yarn
- remove the lockfile requirement by falling back to install when no lockfile is present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e19d9bbb48832c937d74e8b8d5b3b5