### PR TITLE
Add activity feed UI with filters and normalizer tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "prettier": "^3.6.2",
         "tailwindcss": "^3.4.17",
         "tsconfig-paths": "^4.2.0",
-        "tsx": "^4.19.2",
+        "tsx": "^4.20.6",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.45.0"
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "lint": "eslint . --ext .astro,.ts,.tsx,.js",
-    "aggregate": "tsx scripts/aggregate.ts"
+    "aggregate": "tsx scripts/aggregate.ts",
+    "test": "tsx --test \"tests/**/*.test.ts\""
   },
   "dependencies": {
     "@astrojs/mdx": "^4.3.6",
@@ -47,8 +48,8 @@
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "tailwindcss": "^3.4.17",
-    "tsx": "^4.19.2",
     "tsconfig-paths": "^4.2.0",
+    "tsx": "^4.20.6",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.45.0"
   }

--- a/src/components/ActivityList.tsx
+++ b/src/components/ActivityList.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useMemo, useState } from "react";
+import dayjs from "dayjs";
+
+import { normalizeActivity, type ActivityCategory, type NormalizedActivity } from "../lib/activity";
+
+type ActivityFilter = "all" | ActivityCategory;
+
+type FetchState =
+  | { status: "loading" }
+  | { status: "error" }
+  | { status: "ready"; items: NormalizedActivity[] };
+
+const FILTERS: { label: string; value: ActivityFilter }[] = [
+  { label: "All", value: "all" },
+  { label: "GitHub", value: "github" },
+  { label: "Reading", value: "reading" },
+  { label: "Music", value: "music" }
+];
+
+const SOURCE_LABEL: Record<ActivityCategory, string> = {
+  github: "GitHub",
+  reading: "Reading",
+  music: "Music"
+};
+
+type IconProps = { className?: string };
+
+const GitHubIcon = ({ className }: IconProps) => (
+  <svg
+    className={className}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    focusable="false"
+    fill="currentColor"
+  >
+    <path d="M12 1.5a10.5 10.5 0 0 0-3.32 20.48c.53.1.73-.23.73-.5v-1.74c-3 .66-3.63-1.45-3.63-1.45-.48-1.2-1.18-1.53-1.18-1.53-.97-.66.07-.65.07-.65 1.07.08 1.63 1.13 1.63 1.13.95 1.65 2.5 1.18 3.12.9.1-.7.37-1.17.67-1.44-2.39-.28-4.9-1.2-4.9-5.34 0-1.18.42-2.16 1.1-2.92-.11-.27-.48-1.38.1-2.88 0 0 .9-.29 2.95 1.11a10.2 10.2 0 0 1 5.37 0c2.05-1.4 2.95-1.11 2.95-1.11.58 1.5.22 2.61.11 2.88.68.76 1.1 1.74 1.1 2.92 0 4.16-2.52 5.05-4.92 5.33.39.34.74 1 .74 2.02v2.99c0 .28.2.62.74.51A10.5 10.5 0 0 0 12 1.5Z" />
+  </svg>
+);
+
+const BookIcon = ({ className }: IconProps) => (
+  <svg
+    className={className}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    focusable="false"
+    fill="currentColor"
+  >
+    <path d="M5.25 3.5a2.75 2.75 0 0 0-2.75 2.75v11.5A2.75 2.75 0 0 0 5.25 20.5H9.5c1.5 0 2.75 1 2.75 2.25V5A1.5 1.5 0 0 0 10.75 3.5H5.25Zm13.5 0h-5.5A1.5 1.5 0 0 0 11.5 5v17.75c0-1.25 1.25-2.25 2.75-2.25h4.25a2.75 2.75 0 0 0 2.75-2.75V6.25A2.75 2.75 0 0 0 18.75 3.5Z" />
+  </svg>
+);
+
+const MusicIcon = ({ className }: IconProps) => (
+  <svg
+    className={className}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    focusable="false"
+    fill="currentColor"
+  >
+    <path d="M19 3.25a.75.75 0 0 0-.88-.74l-9 1.5a.75.75 0 0 0-.62.74v9.45a3.25 3.25 0 1 0 1.5 2.75V9.94l7.5-1.25v4.55a3.25 3.25 0 1 0 1.5 2.75V3.25Z" />
+  </svg>
+);
+
+const ICON_MAP: Record<ActivityCategory, (props: IconProps) => JSX.Element> = {
+  github: GitHubIcon,
+  reading: BookIcon,
+  music: MusicIcon
+};
+
+const ActivityList = (): JSX.Element => {
+  const [filter, setFilter] = useState<ActivityFilter>("all");
+  const [state, setState] = useState<FetchState>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchData = async () => {
+      try {
+        const response = await fetch("/data/activity.json", { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+        const payload = await response.json();
+        if (!cancelled) {
+          const items = normalizeActivity(payload);
+          setState({ status: "ready", items });
+        }
+      } catch (error) {
+        console.error("Failed to load activity feed", error);
+        if (!cancelled) {
+          setState({ status: "error" });
+        }
+      }
+    };
+
+    fetchData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const items = state.status === "ready" ? state.items : [];
+
+  const filteredItems = useMemo(() => {
+    if (filter === "all") return items;
+    return items.filter((item) => item.category === filter);
+  }, [filter, items]);
+
+  const groups = useMemo(() => {
+    const byDate = new Map<string, NormalizedActivity[]>();
+
+    filteredItems.forEach((item) => {
+      const key = dayjs(item.createdAt).format("YYYY-MM-DD");
+      const existing = byDate.get(key) ?? [];
+      existing.push(item);
+      byDate.set(key, existing);
+    });
+
+    return Array.from(byDate.entries())
+      .map(([dateKey, entries]) => ({
+        dateKey,
+        label: formatDayLabel(dateKey),
+        entries: entries.sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))
+      }))
+      .sort((a, b) => dayjs(b.dateKey).valueOf() - dayjs(a.dateKey).valueOf());
+  }, [filteredItems]);
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-wrap gap-2">
+        {FILTERS.map((item) => (
+          <button
+            key={item.value}
+            type="button"
+            onClick={() => setFilter(item.value)}
+            className={`rounded-full border px-4 py-1.5 text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${
+              filter === item.value
+                ? "border-transparent bg-accent text-white shadow-sm"
+                : "border-border/70 bg-surface/80 text-text-secondary hover:bg-surface"
+            }`}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+
+      {state.status === "error" ? (
+        <div className="rounded-3xl border border-border/70 bg-surface/60 p-6 text-sm text-text-secondary">
+          <p className="font-medium text-text-primary">Something went wrong.</p>
+          <p className="mt-2">Unable to load the activity feed right now. Please refresh to try again.</p>
+        </div>
+      ) : state.status === "loading" ? (
+        <LoadingSkeleton />
+      ) : groups.length === 0 ? (
+        <div className="rounded-3xl border border-dashed border-border/60 bg-surface/40 p-8 text-center text-sm text-text-secondary">
+          <p>No activity yet. Once the feed updates, it will appear here.</p>
+        </div>
+      ) : (
+        <div className="space-y-10">
+          {groups.map((group) => (
+            <section key={group.dateKey} className="space-y-4">
+              <div className="flex items-center gap-3">
+                <div className="h-[1px] flex-1 bg-border/50" aria-hidden="true" />
+                <p className="text-xs uppercase tracking-[0.2em] text-text-muted">{group.label}</p>
+                <div className="h-[1px] flex-1 bg-border/50" aria-hidden="true" />
+              </div>
+              <ul className="space-y-3">
+                {group.entries.map((item) => (
+                  <li
+                    key={item.id}
+                    className="group flex items-start gap-4 rounded-3xl border border-border/60 bg-background/60 p-5 transition hover:border-border/40 hover:bg-background/80"
+                  >
+                    <IconFor source={item.category} />
+                    <div className="space-y-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        {item.url ? (
+                          <a
+                            href={item.url}
+                            className="font-medium text-text-primary underline-offset-4 transition hover:text-accent hover:underline"
+                          >
+                            {item.title}
+                          </a>
+                        ) : (
+                          <p className="font-medium text-text-primary">{item.title}</p>
+                        )}
+                        <span className="text-xs uppercase tracking-wide text-text-muted">
+                          {SOURCE_LABEL[item.category]}
+                        </span>
+                      </div>
+                      {item.description && (
+                        <p className="text-sm text-text-secondary">{item.description}</p>
+                      )}
+                      <p className="text-xs text-text-muted">{dayjs(item.createdAt).format("h:mm A")}</p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const IconFor = ({ source }: { source: ActivityCategory }) => {
+  const Icon = ICON_MAP[source];
+  return (
+    <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-accent-soft text-accent">
+      <Icon className="h-5 w-5" />
+    </div>
+  );
+};
+
+const LoadingSkeleton = () => (
+  <div className="space-y-10">
+    {[0, 1, 2].map((group) => (
+      <section key={group} className="space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="h-[1px] flex-1 bg-border/40" aria-hidden="true" />
+          <div className="h-2 w-24 rounded-full bg-border/40" />
+          <div className="h-[1px] flex-1 bg-border/40" aria-hidden="true" />
+        </div>
+        <ul className="space-y-3">
+          {[0, 1, 2].map((item) => (
+            <li
+              key={item}
+              className="flex items-start gap-4 rounded-3xl border border-border/50 bg-background/40 p-5"
+            >
+              <div className="h-11 w-11 rounded-2xl bg-border/30" />
+              <div className="space-y-2">
+                <div className="h-4 w-48 rounded-full bg-border/30" />
+                <div className="h-3 w-32 rounded-full bg-border/20" />
+                <div className="h-2 w-20 rounded-full bg-border/20" />
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+    ))}
+  </div>
+);
+
+function formatDayLabel(dateKey: string): string {
+  const date = dayjs(dateKey);
+  if (date.isSame(dayjs(), "day")) return "Today";
+  if (date.isSame(dayjs().subtract(1, "day"), "day")) return "Yesterday";
+  return date.format("MMMM D, YYYY");
+}
+
+export default ActivityList;

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -1,0 +1,133 @@
+export type GithubActivity = {
+  source: "github";
+  type?: string | null;
+  repo?: string | null;
+  title?: string | null;
+  url?: string | null;
+  createdAt?: string | null;
+};
+
+export type RssActivity = {
+  source: "rss";
+  title?: string | null;
+  url?: string | null;
+  createdAt?: string | null;
+  feedTitle?: string | null;
+};
+
+export type LastFmActivity = {
+  source: "lastfm";
+  artist?: string | null;
+  track?: string | null;
+  url?: string | null;
+  createdAt?: string | null;
+};
+
+export type RawActivity = GithubActivity | RssActivity | LastFmActivity;
+
+export type ActivityCategory = "github" | "reading" | "music";
+
+export type NormalizedActivity = {
+  id: string;
+  category: ActivityCategory;
+  title: string;
+  description?: string;
+  createdAt: string;
+  url: string | null;
+};
+
+const SOURCE_CATEGORY_MAP: Record<RawActivity["source"], ActivityCategory> = {
+  github: "github",
+  rss: "reading",
+  lastfm: "music"
+};
+
+const SOURCE_TITLE_FALLBACK: Record<ActivityCategory, string> = {
+  github: "GitHub activity",
+  reading: "Reading",
+  music: "Listening"
+};
+
+function toIsoDate(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const time = Date.parse(value);
+  if (!Number.isFinite(time)) return null;
+  return new Date(time).toISOString();
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32);
+}
+
+export function normalizeActivity(raw: unknown): NormalizedActivity[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  const normalized: NormalizedActivity[] = [];
+
+  raw.forEach((item, index) => {
+    if (!item || typeof item !== "object") {
+      return;
+    }
+
+    const typed = item as RawActivity;
+    if (!typed.source || !(typed.source in SOURCE_CATEGORY_MAP)) {
+      return;
+    }
+
+    const category = SOURCE_CATEGORY_MAP[typed.source];
+    const isoDate = toIsoDate(typed.createdAt ?? null);
+    if (!isoDate) {
+      return;
+    }
+
+    let title = "";
+    let description: string | undefined;
+    let url: string | null = null;
+
+    switch (typed.source) {
+      case "github": {
+        title = (typed.title ?? typed.type ?? undefined) ?? SOURCE_TITLE_FALLBACK[category];
+        description = typed.repo ?? undefined;
+        url = typeof typed.url === "string" ? typed.url : null;
+        break;
+      }
+      case "rss": {
+        title = typed.title ?? typed.url ?? SOURCE_TITLE_FALLBACK[category];
+        description = typed.feedTitle ?? undefined;
+        url = typeof typed.url === "string" ? typed.url : null;
+        break;
+      }
+      case "lastfm": {
+        const track = typed.track ?? undefined;
+        const artist = typed.artist ?? undefined;
+        title = track ?? SOURCE_TITLE_FALLBACK[category];
+        description = artist ?? undefined;
+        url = typeof typed.url === "string" ? typed.url : null;
+        break;
+      }
+      default:
+        return;
+    }
+
+    const safeTitle = title && typeof title === "string" ? title : SOURCE_TITLE_FALLBACK[category];
+    const baseId = `${category}-${isoDate}-${slugify(safeTitle) || "item"}`;
+    const id = `${baseId}-${index}`;
+
+    normalized.push({
+      id,
+      category,
+      title: safeTitle,
+      description,
+      createdAt: isoDate,
+      url
+    });
+  });
+
+  return normalized.sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
+}

--- a/src/pages/activity.astro
+++ b/src/pages/activity.astro
@@ -1,5 +1,6 @@
 ---
 import AppShell from "../layouts/AppShell.astro";
+import ActivityList from "../components/ActivityList";
 ---
 
 <AppShell>
@@ -10,19 +11,17 @@ import AppShell from "../layouts/AppShell.astro";
       content="A running log of what Ashton Hawkins is building, reading, and shipping."
     />
   </fragment>
-  <section class="space-y-8">
-    <header class="max-w-prose space-y-4">
+  <section class="space-y-10">
+    <header class="max-w-2xl space-y-4">
       <h1 class="text-4xl font-semibold text-text-primary">Activity</h1>
       <p class="text-lg text-text-secondary">
-        Soon this page will aggregate commits, talks, playlists, and other signals of what’s in
-        motion. For now, it’s a placeholder while the data pipeline comes together.
+        A cross-network feed of what’s in motion&mdash;from GitHub commits to reading highlights
+        and the latest tracks on repeat.
+      </p>
+      <p class="text-sm text-text-muted">
+        Use the filters to zero in on a specific channel or browse everything together.
       </p>
     </header>
-    <div class="rounded-3xl border border-dashed border-border/70 bg-surface/50 p-10 text-sm text-text-secondary">
-      <p>
-        I’m currently wiring up a JSON feed that will surface project updates, reading lists, and
-        small wins. Check back shortly—or subscribe to the now page for updates.
-      </p>
-    </div>
+    <ActivityList client:load />
   </section>
 </AppShell>

--- a/tests/activity-normalizer.test.ts
+++ b/tests/activity-normalizer.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { normalizeActivity, type NormalizedActivity, type RawActivity } from "../src/lib/activity";
+
+describe("normalizeActivity", () => {
+  it("normalizes GitHub entries", () => {
+    const raw: RawActivity[] = [
+      {
+        source: "github",
+        title: "Pushed 2 commits",
+        repo: "ashtonhawkins/site",
+        url: "https://github.com/ashtonhawkins/site",
+        createdAt: "2024-01-01T12:00:00Z"
+      }
+    ];
+
+    const result = normalizeActivity(raw);
+    assert.equal(result.length, 1);
+    const item = result[0];
+    assert.equal(item.category, "github");
+    assert.equal(item.title, "Pushed 2 commits");
+    assert.equal(item.description, "ashtonhawkins/site");
+    assert.equal(item.url, "https://github.com/ashtonhawkins/site");
+  });
+
+  it("maps RSS items to the reading category", () => {
+    const raw: RawActivity[] = [
+      {
+        source: "rss",
+        title: "Designing calm interfaces",
+        url: "https://example.com/articles/calm",
+        createdAt: "2024-02-10T09:30:00Z",
+        feedTitle: "Reading Log"
+      }
+    ];
+
+    const result = normalizeActivity(raw);
+    assert.equal(result.length, 1);
+    const item = result[0];
+    assert.equal(item.category, "reading");
+    assert.equal(item.description, "Reading Log");
+  });
+
+  it("handles Last.fm items as music", () => {
+    const raw: RawActivity[] = [
+      {
+        source: "lastfm",
+        artist: "Khruangbin",
+        track: "August 12",
+        url: "https://last.fm/track",
+        createdAt: "2024-03-05T21:15:00Z"
+      }
+    ];
+
+    const result = normalizeActivity(raw);
+    assert.equal(result.length, 1);
+    const item = result[0];
+    assert.equal(item.category, "music");
+    assert.equal(item.title, "August 12");
+    assert.equal(item.description, "Khruangbin");
+  });
+
+  it("filters out invalid entries", () => {
+    const raw = [
+      { source: "github", createdAt: "not-a-date" },
+      { source: "rss", createdAt: null },
+      { source: "unknown", createdAt: "2024-01-01T00:00:00Z" }
+    ];
+
+    const result = normalizeActivity(raw);
+    assert.deepEqual(result, []);
+  });
+
+  it("sorts normalized entries by descending date", () => {
+    const raw: RawActivity[] = [
+      {
+        source: "rss",
+        title: "Second",
+        url: "https://example.com/second",
+        createdAt: "2024-01-02T00:00:00Z"
+      },
+      {
+        source: "rss",
+        title: "First",
+        url: "https://example.com/first",
+        createdAt: "2024-01-01T00:00:00Z"
+      }
+    ];
+
+    const result = normalizeActivity(raw);
+    assert.deepEqual(
+      result.map((item: NormalizedActivity) => item.title),
+      ["Second", "First"]
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a client-loaded ActivityList component that fetches the aggregated JSON feed, groups entries by day, and supports filter controls with loading and error states
- introduce a shared activity normalizer utility and cover its scenarios with runtime tests
- refresh the activity page copy and mount the new feed experience

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e1a856bd5c832c9b156c94d633b693