### PR TITLE
Implement command palette navigation and search focus

### DIFF
--- a/src/layouts/AppShell.astro
+++ b/src/layouts/AppShell.astro
@@ -104,8 +104,40 @@ const navLinks = [
         });
       };
 
-      attachCommandButton();
-      document.addEventListener('astro:page-load', attachCommandButton);
+      const bindCommandPaletteShortcut = () => {
+        if (window.__commandPaletteShortcutBound) return;
+
+        const handleShortcut = (event) => {
+          if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+            event.preventDefault();
+            window.dispatchEvent(new CustomEvent('command-palette:toggle'));
+          }
+
+          if (event.key === 'Escape') {
+            window.dispatchEvent(new CustomEvent('command-palette:close'));
+          }
+        };
+
+        window.addEventListener('keydown', handleShortcut);
+        window.__commandPaletteShortcutBound = true;
+
+        document.addEventListener(
+          'astro:before-swap',
+          () => {
+            window.removeEventListener('keydown', handleShortcut);
+            window.__commandPaletteShortcutBound = false;
+          },
+          { once: true }
+        );
+      };
+
+      const initCommandPalette = () => {
+        attachCommandButton();
+        bindCommandPaletteShortcut();
+      };
+
+      initCommandPalette();
+      document.addEventListener('astro:page-load', initCommandPalette);
     </script>
     <script type="module" src={lenisScript}></script>
   </body>


### PR DESCRIPTION
## Summary
- replace the command palette with dedicated navigation commands and a site search action that focuses the Pagefind input
- wire AppShell to dispatch palette open/toggle events from the header button and the ⌘/Ctrl+K keyboard shortcut

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any errors in scripts/aggregate.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a9c95b58832ca63c4b37df1aa6a1