### PR TITLE
Add resume page sourced from JSON Resume data

### DIFF
--- a/src/content/resume.json
+++ b/src/content/resume.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://jsonresume.org/schema",
+  "basics": {
+    "name": "Ashton Hawkins",
+    "label": "Product Designer & Engineer",
+    "email": "ashton@example.com",
+    "phone": "+1 (555) 123-4567",
+    "url": "https://ashtonhawkins.com",
+    "summary": "Hybrid designer-engineer building thoughtful digital products that balance craft, performance, and clarity.",
+    "location": {
+      "city": "Austin",
+      "region": "Texas",
+      "countryCode": "US"
+    },
+    "profiles": [
+      {
+        "network": "LinkedIn",
+        "username": "ashtonhawkins",
+        "url": "https://www.linkedin.com/in/ashtonhawkins"
+      },
+      {
+        "network": "GitHub",
+        "username": "ashtonhawkins",
+        "url": "https://github.com/ashtonhawkins"
+      }
+    ]
+  },
+  "work": [
+    {
+      "name": "Studio Meridian",
+      "position": "Founder & Principal Designer",
+      "url": "https://studiomeridian.com",
+      "startDate": "2020-01-01",
+      "summary": "Lead multi-disciplinary client engagements from discovery through launch, shaping product vision, interaction patterns, and shipping reliable systems.",
+      "highlights": [
+        "Scaled a design system that reduced feature delivery time by 35% across three product teams.",
+        "Facilitated research sprints that informed roadmap priorities for executive stakeholders.",
+        "Delivered spatial computing prototypes to validate next-generation collaboration workflows."
+      ]
+    },
+    {
+      "name": "Northwind Labs",
+      "position": "Senior Product Engineer",
+      "url": "https://northwindlabs.io",
+      "startDate": "2016-06-01",
+      "endDate": "2019-12-01",
+      "summary": "Partnered with design and data science teams to craft responsive web apps focused on rich media publishing and analytics.",
+      "highlights": [
+        "Shipped a modular front-end architecture adopted by four internal product lines.",
+        "Championed accessibility standards resulting in WCAG 2.1 AA compliance across flagship properties.",
+        "Mentored cross-functional team members through code reviews and design critiques."
+      ]
+    }
+  ],
+  "education": [
+    {
+      "institution": "Parsons School of Design",
+      "area": "Communication Design",
+      "studyType": "BFA",
+      "startDate": "2011-09-01",
+      "endDate": "2015-05-01",
+      "summary": "Focused on interactive systems, human-centered research, and digital fabrication.",
+      "courses": [
+        "Interaction Design Studio",
+        "Visual Systems",
+        "Creative Coding"
+      ]
+    }
+  ],
+  "projects": [
+    {
+      "name": "Signal Atlas",
+      "description": "Mapping toolkit helping distributed teams align around product signals and qualitative research findings.",
+      "highlights": [
+        "Built as an internal-first tool and later productized for enterprise clients.",
+        "Integrated AI summarization workflows to accelerate research synthesis."
+      ],
+      "keywords": ["Design Systems", "Spatial Interfaces", "Research Ops"],
+      "url": "https://signalatlas.app",
+      "roles": ["Product Strategy", "Design", "Engineering"]
+    },
+    {
+      "name": "Field Notes",
+      "description": "A publication and toolkit series sharing experiments in slow web practices and creative tooling.",
+      "highlights": [
+        "Grew newsletter audience to 5k+ independent builders.",
+        "Collaborated with guest contributors for themed issues focused on prototyping and systems thinking."
+      ],
+      "keywords": ["Publishing", "Tooling", "Community"],
+      "url": "https://fieldnotes.studio",
+      "roles": ["Editor", "Designer", "Developer"]
+    }
+  ],
+  "skills": [
+    {
+      "name": "Design",
+      "level": "Expert",
+      "keywords": [
+        "Product Discovery",
+        "Design Systems",
+        "Interaction Design",
+        "Prototyping"
+      ]
+    },
+    {
+      "name": "Engineering",
+      "level": "Advanced",
+      "keywords": [
+        "TypeScript",
+        "Astro",
+        "React",
+        "Node.js"
+      ]
+    }
+  ]
+}

--- a/src/layouts/AppShell.astro
+++ b/src/layouts/AppShell.astro
@@ -8,6 +8,7 @@ import lenisScript from "../scripts/lenis.ts?url";
 const navLinks = [
   { href: "/", label: "Home" },
   { href: "/about", label: "About" },
+  { href: "/resume", label: "Resume" },
   { href: "/now", label: "Now" },
   { href: "/writing", label: "Writing" },
   { href: "/projects", label: "Projects" },

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -1,0 +1,236 @@
+---
+import AppShell from "../layouts/AppShell.astro";
+import resume from "../content/resume.json";
+
+const { basics = {}, work = [], education = [], projects = [], skills = [] } = resume as {
+  basics?: Record<string, any>;
+  work?: Record<string, any>[];
+  education?: Record<string, any>[];
+  projects?: Record<string, any>[];
+  skills?: Record<string, any>[];
+};
+
+const formatDate = (value?: string) => {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return value;
+  return new Intl.DateTimeFormat("en", { month: "short", year: "numeric" }).format(date);
+};
+
+const formatRange = (start?: string, end?: string) => {
+  if (!start && !end) return undefined;
+  const startLabel = start ? formatDate(start) : undefined;
+  const endLabel = end ? formatDate(end) : "Present";
+  return [startLabel, endLabel].filter(Boolean).join(" – ") || undefined;
+};
+
+const locationParts = [basics?.location?.city, basics?.location?.region, basics?.location?.countryCode].filter(Boolean);
+const hasSummary = Boolean(basics?.summary);
+---
+
+<AppShell>
+  <fragment slot="head">
+    <title>Resume · {basics?.name ?? "Ashton Hawkins"}</title>
+    <meta
+      name="description"
+      content={
+        basics?.summary
+          ? `${basics.name}'s resume – ${basics.summary}`
+          : "A snapshot of work, education, projects, and skills."
+      }
+    />
+  </fragment>
+  <article class="mx-auto flex w-full max-w-4xl flex-col gap-12 text-base text-text-secondary">
+    <header class="flex flex-col gap-6 border-b border-border/60 pb-10">
+      <div class="flex flex-col gap-3">
+        <p class="text-sm font-semibold uppercase tracking-widest text-accent">Resume</p>
+        <h1 class="text-3xl font-semibold text-text-primary md:text-4xl">{basics?.name ?? "Ashton Hawkins"}</h1>
+        {basics?.label && <p class="text-lg text-text-secondary">{basics.label}</p>}
+        {(hasSummary || locationParts.length > 0) && (
+          <div class="flex flex-col gap-2 text-sm text-text-muted md:flex-row md:items-center md:gap-4">
+            {hasSummary && <p class="max-w-2xl leading-relaxed text-text-secondary">{basics.summary}</p>}
+            {locationParts.length > 0 && (
+              <p class="font-medium text-text-secondary">{locationParts.join(", ")}</p>
+            )}
+          </div>
+        )}
+      </div>
+      <div class="flex flex-wrap items-center gap-3 text-sm">
+        {basics?.email && (
+          <a class="text-accent underline-offset-4 transition hover:underline" href={`mailto:${basics.email}`}>
+            {basics.email}
+          </a>
+        )}
+        {basics?.phone && <span class="text-text-muted">{basics.phone}</span>}
+        {basics?.url && (
+          <a class="text-accent underline-offset-4 transition hover:underline" href={basics.url}>
+            {basics.url.replace(/^https?:\/\//, "")}
+          </a>
+        )}
+        {Array.isArray(basics?.profiles) && basics.profiles.length > 0 && (
+          <span class="flex flex-wrap items-center gap-2 text-text-muted">
+            {basics.profiles.map((profile) => (
+              <a class="text-accent underline-offset-4 transition hover:underline" href={profile.url}>
+                {profile.network}
+              </a>
+            ))}
+          </span>
+        )}
+      </div>
+      <div class="flex flex-wrap gap-3">
+        <a
+          href="/resume.json"
+          download
+          class="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-medium text-text-secondary shadow-soft transition hover:border-accent hover:bg-accent-soft hover:text-text-primary hover:shadow-ring"
+        >
+          Download JSON
+        </a>
+        <button
+          type="button"
+          onclick="window.print()"
+          class="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-medium text-text-secondary shadow-soft transition hover:border-accent hover:bg-accent-soft hover:text-text-primary hover:shadow-ring"
+        >
+          Print to PDF
+        </button>
+      </div>
+    </header>
+
+    {work.length > 0 && (
+      <section class="flex flex-col gap-6">
+        <div class="space-y-2">
+          <h2 class="text-2xl font-semibold text-text-primary">Work</h2>
+          <p class="text-sm text-text-muted">
+            Select roles that blend strategy, systems, and hands-on making.
+          </p>
+        </div>
+        <div class="flex flex-col gap-8">
+          {work.map((role) => (
+            <article class="flex flex-col gap-3">
+              <header class="flex flex-col gap-1">
+                <div class="flex flex-wrap items-center justify-between gap-2">
+                  <h3 class="text-lg font-semibold text-text-primary">
+                    {role.position} · {role.name}
+                  </h3>
+                  {formatRange(role.startDate, role.endDate) && (
+                    <span class="text-xs uppercase tracking-wide text-text-muted">
+                      {formatRange(role.startDate, role.endDate)}
+                    </span>
+                  )}
+                </div>
+                {role.summary && <p class="text-sm text-text-secondary">{role.summary}</p>}
+              </header>
+              {Array.isArray(role.highlights) && role.highlights.length > 0 && (
+                <ul class="list-disc space-y-2 pl-6 text-sm text-text-secondary">
+                  {role.highlights.map((highlight) => (
+                    <li>{highlight}</li>
+                  ))}
+                </ul>
+              )}
+            </article>
+          ))}
+        </div>
+      </section>
+    )}
+
+    {projects.length > 0 && (
+      <section class="flex flex-col gap-6">
+        <div class="space-y-2">
+          <h2 class="text-2xl font-semibold text-text-primary">Projects</h2>
+          <p class="text-sm text-text-muted">Selected experiments and products shipped independently or with collaborators.</p>
+        </div>
+        <div class="grid gap-8 md:grid-cols-2">
+          {projects.map((project) => (
+            <article class="flex h-full flex-col gap-3 rounded-2xl border border-border/60 bg-surface/50 p-6 shadow-soft">
+              <header class="flex flex-col gap-1">
+                <div class="flex items-center justify-between gap-2">
+                  <h3 class="text-lg font-semibold text-text-primary">{project.name}</h3>
+                  {project.url && (
+                    <a class="text-sm font-medium text-accent underline-offset-4 hover:underline" href={project.url}>
+                      Visit
+                    </a>
+                  )}
+                </div>
+                {project.description && <p class="text-sm text-text-secondary">{project.description}</p>}
+              </header>
+              {Array.isArray(project.highlights) && project.highlights.length > 0 && (
+                <ul class="list-disc space-y-2 pl-5 text-sm text-text-secondary">
+                  {project.highlights.map((highlight) => (
+                    <li>{highlight}</li>
+                  ))}
+                </ul>
+              )}
+              <div class="mt-auto flex flex-wrap items-center gap-2 text-xs uppercase tracking-wide text-text-muted">
+                {Array.isArray(project.roles) &&
+                  project.roles.map((role) => <span class="rounded-full bg-surface px-3 py-1 text-text-secondary">{role}</span>)}
+                {Array.isArray(project.keywords) &&
+                  project.keywords.map((keyword) => (
+                    <span class="rounded-full bg-accent-soft px-3 py-1 text-accent">{keyword}</span>
+                  ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    )}
+
+    {education.length > 0 && (
+      <section class="flex flex-col gap-6">
+        <div class="space-y-2">
+          <h2 class="text-2xl font-semibold text-text-primary">Education</h2>
+          <p class="text-sm text-text-muted">Academic foundations and areas of study.</p>
+        </div>
+        <div class="flex flex-col gap-6">
+          {education.map((entry) => (
+            <article class="flex flex-col gap-2">
+              <div class="flex flex-wrap items-center justify-between gap-2">
+                <h3 class="text-lg font-semibold text-text-primary">{entry.institution}</h3>
+                {formatRange(entry.startDate, entry.endDate) && (
+                  <span class="text-xs uppercase tracking-wide text-text-muted">
+                    {formatRange(entry.startDate, entry.endDate)}
+                  </span>
+                )}
+              </div>
+              <p class="text-sm text-text-secondary">
+                {entry.studyType} in {entry.area}
+              </p>
+              {entry.summary && <p class="text-sm text-text-secondary">{entry.summary}</p>}
+              {Array.isArray(entry.courses) && entry.courses.length > 0 && (
+                <ul class="flex flex-wrap gap-2 text-xs uppercase tracking-wide text-text-muted">
+                  {entry.courses.map((course) => (
+                    <li class="rounded-full bg-surface px-3 py-1 text-text-secondary">{course}</li>
+                  ))}
+                </ul>
+              )}
+            </article>
+          ))}
+        </div>
+      </section>
+    )}
+
+    {skills.length > 0 && (
+      <section class="flex flex-col gap-6">
+        <div class="space-y-2">
+          <h2 class="text-2xl font-semibold text-text-primary">Skills</h2>
+          <p class="text-sm text-text-muted">Tools, processes, and domains that guide current work.</p>
+        </div>
+        <div class="grid gap-6 md:grid-cols-2">
+          {skills.map((skill) => (
+            <article class="flex flex-col gap-3 rounded-2xl border border-border/60 bg-surface/60 p-5 shadow-soft">
+              <header class="flex items-center justify-between">
+                <h3 class="text-lg font-semibold text-text-primary">{skill.name}</h3>
+                {skill.level && <span class="text-xs uppercase tracking-wide text-text-muted">{skill.level}</span>}
+              </header>
+              {Array.isArray(skill.keywords) && skill.keywords.length > 0 && (
+                <ul class="flex flex-wrap gap-2 text-sm text-text-secondary">
+                  {skill.keywords.map((keyword) => (
+                    <li class="rounded-full bg-surface px-3 py-1 text-text-secondary">{keyword}</li>
+                  ))}
+                </ul>
+              )}
+            </article>
+          ))}
+        </div>
+      </section>
+    )}
+  </article>
+</AppShell>

--- a/src/pages/resume.json.ts
+++ b/src/pages/resume.json.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from "astro";
+import resume from "../content/resume.json";
+
+export const GET: APIRoute = () => {
+  return new Response(JSON.stringify(resume, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "public, max-age=3600"
+    }
+  });
+};


### PR DESCRIPTION
## Summary
- add a JSON Resume-compliant content file that captures placeholder work, education, project, and skill data
- create a dedicated /resume page that renders resume sections with download and print actions
- expose the resume data as a downloadable JSON endpoint and link it in the site navigation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e1ab9e6704832ca6ec7b4f64faea28