### PR TITLE
Add centralized SEO handling and ensure sitemap.xml output

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,9 +1,49 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "astro/config";
 import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 import tailwind from "@astrojs/tailwind";
 import pagefind from "astro-pagefind";
+
+const ensureSitemapXml = {
+  name: "ensure-sitemap-xml",
+  hooks: {
+    "astro:build:done": async ({ dir, logger }) => {
+      const outputDir = fileURLToPath(dir);
+      const sitemapPartPath = path.join(outputDir, "sitemap-0.xml");
+      const sitemapIndexPath = path.join(outputDir, "sitemap-index.xml");
+      const sitemapPath = path.join(outputDir, "sitemap.xml");
+
+      try {
+        await fs.copyFile(sitemapPartPath, sitemapPath);
+        logger.info("`sitemap.xml` created alongside default sitemap output.");
+        return;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          logger.error(
+            `Failed to create sitemap.xml: ${error instanceof Error ? error.message : String(error)}`
+          );
+          return;
+        }
+      }
+
+      try {
+        await fs.copyFile(sitemapIndexPath, sitemapPath);
+        logger.info("`sitemap.xml` created from sitemap index output.");
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          logger.error(
+            `Failed to create sitemap.xml: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+      }
+    }
+  }
+};
 
 export default defineConfig({
   site: "https://ashtonhawkins.com",
@@ -19,7 +59,8 @@ export default defineConfig({
         resetStyles: false
       }
     }),
-    sitemap()
+    sitemap(),
+    ensureSitemapXml
   ],
   prefetch: {
     defaultStrategy: "viewport"

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -1,0 +1,82 @@
+---
+interface Props {
+  title: string;
+  description: string;
+  ogTitle?: string;
+}
+
+const { title, description, ogTitle } = Astro.props as Props;
+
+const siteUrl = Astro.site?.origin ?? Astro.url?.origin ?? "";
+const canonicalUrl = Astro.site
+  ? new URL(Astro.url.pathname, Astro.site).toString()
+  : Astro.url?.href ?? "";
+const openGraphTitle = ogTitle ?? title;
+const isHomepage = Astro.url?.pathname === "/";
+const isArticle = Astro.url?.pathname.startsWith("/writing/") ?? false;
+const siteName = "Ashton Hawkins";
+
+const structuredData: Record<string, unknown>[] = [];
+
+if (isHomepage && siteUrl) {
+  structuredData.push(
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "@id": `${siteUrl}#person`,
+      name: siteName,
+      url: siteUrl,
+      description,
+      jobTitle: "Builder, designer, and systems thinker"
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "@id": `${siteUrl}#website`,
+      name: siteName,
+      url: siteUrl,
+      description,
+      publisher: {
+        "@id": `${siteUrl}#person`
+      }
+    }
+  );
+}
+
+if (isArticle && canonicalUrl) {
+  structuredData.push({
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: openGraphTitle,
+    description,
+    mainEntityOfPage: canonicalUrl,
+    author: {
+      "@type": "Person",
+      name: siteName,
+      url: siteUrl || undefined
+    },
+    publisher: {
+      "@type": "Person",
+      name: siteName,
+      url: siteUrl || undefined
+    }
+  });
+}
+---
+<title>{title}</title>
+<meta name="description" content={description} />
+{canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+<meta property="og:type" content={isArticle ? "article" : "website"} />
+{siteName && <meta property="og:site_name" content={siteName} />}
+{canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
+<meta property="og:title" content={openGraphTitle} />
+<meta property="og:description" content={description} />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:title" content={openGraphTitle} />
+<meta name="twitter:description" content={description} />
+{structuredData.map((schema) => (
+  <script
+    type="application/ld+json"
+    set:html={JSON.stringify(schema, (_key, value) => (value === undefined ? undefined : value))}
+  />
+))}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,12 +1,14 @@
 ---
 import AppShell from "../layouts/AppShell.astro";
+import SEO from "../components/SEO.astro";
 ---
 
 <AppShell>
-  <fragment slot="head">
-    <title>About · Ashton Hawkins</title>
-    <meta name="description" content="The long-form story behind the work of Ashton Hawkins." />
-  </fragment>
+  <SEO
+    slot="head"
+    title="About · Ashton Hawkins"
+    description="The long-form story behind the work of Ashton Hawkins."
+  />
   <article class="prose prose-neutral max-w-prose text-base text-text-secondary">
     <h1 class="font-semibold text-text-primary">About</h1>
     <p>

--- a/src/pages/activity.astro
+++ b/src/pages/activity.astro
@@ -1,16 +1,15 @@
 ---
 import AppShell from "../layouts/AppShell.astro";
+import SEO from "../components/SEO.astro";
 import ActivityList from "../components/ActivityList";
 ---
 
 <AppShell>
-  <fragment slot="head">
-    <title>Activity · Ashton Hawkins</title>
-    <meta
-      name="description"
-      content="A running log of what Ashton Hawkins is building, reading, and shipping."
-    />
-  </fragment>
+  <SEO
+    slot="head"
+    title="Activity · Ashton Hawkins"
+    description="A running log of what Ashton Hawkins is building, reading, and shipping."
+  />
   <section class="space-y-10">
     <header class="max-w-2xl space-y-4">
       <h1 class="text-4xl font-semibold text-text-primary">Activity</h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import AppShell from "../layouts/AppShell.astro";
+import SEO from "../components/SEO.astro";
 import NowCard from "../components/NowCard.astro";
 import dayjs from "dayjs";
 import { getCollection } from "astro:content";
@@ -16,13 +17,12 @@ const latestProjects = projectEntries.slice(0, 3);
 ---
 
 <AppShell>
-  <fragment slot="head">
-    <title>Ashton Hawkins · Builder, designer, and systems thinker</title>
-    <meta
-      name="description"
-      content="Creative technologist building thoughtful products across web, AI, and live experiences."
-    />
-  </fragment>
+  <SEO
+    slot="head"
+    title="Ashton Hawkins · Builder, designer, and systems thinker"
+    description="Creative technologist building thoughtful products across web, AI, and live experiences."
+    ogTitle="Ashton Hawkins"
+  />
   <section class="grid gap-16">
     <div class="with-grain relative overflow-hidden rounded-[32px] border border-border/60 bg-surface/60 p-10 shadow-soft">
       <div aria-hidden="true" class="pointer-events-none absolute inset-0 overflow-hidden">

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -1,13 +1,15 @@
 ---
 import AppShell from "../layouts/AppShell.astro";
+import SEO from "../components/SEO.astro";
 import NowCard from "../components/NowCard.astro";
 ---
 
 <AppShell>
-  <fragment slot="head">
-    <title>Now · Ashton Hawkins</title>
-    <meta name="description" content="A snapshot of what Ashton Hawkins is focused on right now." />
-  </fragment>
+  <SEO
+    slot="head"
+    title="Now · Ashton Hawkins"
+    description="A snapshot of what Ashton Hawkins is focused on right now."
+  />
 
   <section class="mx-auto grid max-w-3xl gap-10 text-text-secondary">
     <header class="grid gap-4 text-text-primary">

--- a/src/pages/press/index.astro
+++ b/src/pages/press/index.astro
@@ -1,5 +1,6 @@
 ---
 import AppShell from "../../layouts/AppShell.astro";
+import SEO from "../../components/SEO.astro";
 import { getCollection } from "astro:content";
 import dayjs from "dayjs";
 
@@ -9,13 +10,11 @@ const press = (await getCollection("press")).sort(
 ---
 
 <AppShell>
-  <fragment slot="head">
-    <title>Press · Ashton Hawkins</title>
-    <meta
-      name="description"
-      content="Interviews, features, and mentions of Ashton Hawkins across the web."
-    />
-  </fragment>
+  <SEO
+    slot="head"
+    title="Press · Ashton Hawkins"
+    description="Interviews, features, and mentions of Ashton Hawkins across the web."
+  />
   <section class="space-y-10">
     <header class="max-w-prose space-y-4">
       <h1 class="text-4xl font-semibold text-text-primary">Press</h1>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import AppShell from "../../layouts/AppShell.astro";
+import SEO from "../../components/SEO.astro";
 import dayjs from "dayjs";
 import { getCollection, getEntry } from "astro:content";
 
@@ -23,10 +24,12 @@ export async function getStaticPaths() {
 ---
 
 <AppShell>
-  <fragment slot="head">
-    <title>{title} · Projects · Ashton Hawkins</title>
-    <meta name="description" content={summary} />
-  </fragment>
+  <SEO
+    slot="head"
+    title={`${title} · Projects · Ashton Hawkins`}
+    description={summary}
+    ogTitle={title}
+  />
   <article class="prose prose-neutral mx-auto max-w-prose text-base text-text-secondary">
     <div class="mb-6 flex items-center justify-between gap-4 text-sm text-text-muted">
       <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-border/40 text-2xl">

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,5 +1,6 @@
 ---
 import AppShell from "../../layouts/AppShell.astro";
+import SEO from "../../components/SEO.astro";
 import { getCollection } from "astro:content";
 import dayjs from "dayjs";
 
@@ -9,13 +10,11 @@ const projects = (await getCollection("projects")).sort(
 ---
 
 <AppShell>
-  <fragment slot="head">
-    <title>Projects · Ashton Hawkins</title>
-    <meta
-      name="description"
-      content="Selected work, prototypes, and experiments led by Ashton Hawkins."
-    />
-  </fragment>
+  <SEO
+    slot="head"
+    title="Projects · Ashton Hawkins"
+    description="Selected work, prototypes, and experiments led by Ashton Hawkins."
+  />
   <section class="space-y-10">
     <header class="max-w-prose space-y-4">
       <h1 class="text-4xl font-semibold text-text-primary">Projects</h1>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -1,5 +1,6 @@
 ---
 import AppShell from "../layouts/AppShell.astro";
+import SEO from "../components/SEO.astro";
 import resume from "../content/resume.json";
 
 const { basics = {}, work = [], education = [], projects = [], skills = [] } = resume as {
@@ -26,25 +27,24 @@ const formatRange = (start?: string, end?: string) => {
 
 const locationParts = [basics?.location?.city, basics?.location?.region, basics?.location?.countryCode].filter(Boolean);
 const hasSummary = Boolean(basics?.summary);
+const resumeName = basics?.name ?? "Ashton Hawkins";
+const resumeDescription = hasSummary
+  ? `${resumeName}'s resume – ${basics.summary}`
+  : "A snapshot of work, education, projects, and skills.";
 ---
 
 <AppShell>
-  <fragment slot="head">
-    <title>Resume · {basics?.name ?? "Ashton Hawkins"}</title>
-    <meta
-      name="description"
-      content={
-        basics?.summary
-          ? `${basics.name}'s resume – ${basics.summary}`
-          : "A snapshot of work, education, projects, and skills."
-      }
-    />
-  </fragment>
+  <SEO
+    slot="head"
+    title={`Resume · ${resumeName}`}
+    description={resumeDescription}
+    ogTitle={`Resume · ${resumeName}`}
+  />
   <article class="mx-auto flex w-full max-w-4xl flex-col gap-12 text-base text-text-secondary">
     <header class="flex flex-col gap-6 border-b border-border/60 pb-10">
       <div class="flex flex-col gap-3">
         <p class="text-sm font-semibold uppercase tracking-widest text-accent">Resume</p>
-        <h1 class="text-3xl font-semibold text-text-primary md:text-4xl">{basics?.name ?? "Ashton Hawkins"}</h1>
+        <h1 class="text-3xl font-semibold text-text-primary md:text-4xl">{resumeName}</h1>
         {basics?.label && <p class="text-lg text-text-secondary">{basics.label}</p>}
         {(hasSummary || locationParts.length > 0) && (
           <div class="flex flex-col gap-2 text-sm text-text-muted md:flex-row md:items-center md:gap-4">

--- a/src/pages/writing/[slug].astro
+++ b/src/pages/writing/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import AppShell from "../../layouts/AppShell.astro";
+import SEO from "../../components/SEO.astro";
 import dayjs from "dayjs";
 import { getCollection, getEntry } from "astro:content";
 
@@ -23,10 +24,12 @@ export async function getStaticPaths() {
 ---
 
 <AppShell>
-  <fragment slot="head">
-    <title>{ogTitle ?? title} · Writing · Ashton Hawkins</title>
-    <meta name="description" content={summary} />
-  </fragment>
+  <SEO
+    slot="head"
+    title={`${ogTitle ?? title} · Writing · Ashton Hawkins`}
+    description={summary}
+    ogTitle={ogTitle ?? title}
+  />
   <article class="prose prose-neutral mx-auto max-w-prose text-base text-text-secondary">
     <p class="text-xs uppercase tracking-[0.3em] text-text-muted">
       {dayjs(date).format("MMMM D, YYYY")}

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -1,5 +1,6 @@
 ---
 import AppShell from "../../layouts/AppShell.astro";
+import SEO from "../../components/SEO.astro";
 import { getCollection } from "astro:content";
 import dayjs from "dayjs";
 
@@ -9,13 +10,11 @@ const writing = (await getCollection("writing", ({ data }) => !data.draft)).sort
 ---
 
 <AppShell>
-  <fragment slot="head">
-    <title>Writing · Ashton Hawkins</title>
-    <meta
-      name="description"
-      content="Essays, field notes, and observations from Ashton Hawkins."
-    />
-  </fragment>
+  <SEO
+    slot="head"
+    title="Writing · Ashton Hawkins"
+    description="Essays, field notes, and observations from Ashton Hawkins."
+  />
   <section class="space-y-10">
     <header class="max-w-prose space-y-4">
       <h1 class="text-4xl font-semibold text-text-primary">Writing</h1>


### PR DESCRIPTION
## Summary
- add a reusable SEO component that emits meta tags, Open Graph/Twitter data, and structured JSON-LD
- update pages to use the new SEO component with appropriate defaults per view
- extend the sitemap build to copy the generated file to sitemap.xml for consumers expecting that path

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1adfa6a80832c963338f336f2c760