### PR TITLE
Add Astro GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/astro-deploy.yml
+++ b/.github/workflows/astro-deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy Astro site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Deploy to GitHub Pages
+        uses: withastro/action@v1
+        with:
+          path: .
+          node-version: 20
+          package-manager: npm
+          install-command: npm ci
+          build-command: npm run build
+          deploy-branch: gh-pages
+          cname: ashtonhawkins.com


### PR DESCRIPTION
## Summary
- add an Astro GitHub Pages deployment workflow that runs on pushes to `main`
- configure the withastro deployment action to build with npm and preserve the `ashtonhawkins.com` CNAME

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1af69bbd0832caad556b8775a794a