### PR TITLE
Fix GitHub Pages workflow to use supported actions

### DIFF
--- a/.github/workflows/astro-deploy.yml
+++ b/.github/workflows/astro-deploy.yml
@@ -16,21 +16,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Deploy to GitHub Pages
-        uses: withastro/action@v1
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install, build, and upload
+        uses: withastro/action@v4
         with:
           path: .
           node-version: 20
           package-manager: npm
-          install-command: npm ci
-          build-command: npm run build
-          deploy-branch: gh-pages
-          cname: ashtonhawkins.com
+          build-cmd: npm run build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- update the Astro deployment workflow to use the latest withastro/action release
- switch the workflow to the build/deploy job pattern recommended for GitHub Pages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1b22a34b0832c9aefacc5973a1413