### PR TITLE
Add coming soon placeholder homepage

### DIFF
--- a/src/layouts/AppShell.astro
+++ b/src/layouts/AppShell.astro
@@ -5,6 +5,10 @@ import ThemeToggle from "../components/ThemeToggle";
 import SearchBox from "../components/SearchBox.astro";
 import lenisScript from "../scripts/lenis.ts?url";
 
+interface Props {
+  hideNavigation?: boolean;
+}
+
 const navLinks = [
   { href: "/", label: "Home" },
   { href: "/about", label: "About" },
@@ -15,6 +19,8 @@ const navLinks = [
   { href: "/press", label: "Press" },
   { href: "/activity", label: "Activity" }
 ];
+
+const { hideNavigation = false } = Astro.props as Props;
 ---
 
 <!DOCTYPE html>
@@ -48,18 +54,20 @@ const navLinks = [
         >
           Ashton Hawkins
         </a>
-        <nav class="hidden items-center gap-2 text-sm font-medium md:flex">
-          {navLinks.map((link) => (
-            <a
-              transition:animate
-              href={link.href}
-              class="rounded-full px-4 py-2 text-text-secondary transition-all hover:bg-accent-soft hover:text-text-primary"
-              data-astro-transition="animate"
-            >
-              {link.label}
-            </a>
-          ))}
-        </nav>
+        {!hideNavigation && (
+          <nav class="hidden items-center gap-2 text-sm font-medium md:flex">
+            {navLinks.map((link) => (
+              <a
+                transition:animate
+                href={link.href}
+                class="rounded-full px-4 py-2 text-text-secondary transition-all hover:bg-accent-soft hover:text-text-primary"
+                data-astro-transition="animate"
+              >
+                {link.label}
+              </a>
+            ))}
+          </nav>
+        )}
         <div class="flex items-center gap-2">
           <button
             type="button"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,239 +1,34 @@
 ---
 import AppShell from "../layouts/AppShell.astro";
 import SEO from "../components/SEO.astro";
-import NowCard from "../components/NowCard.astro";
-import dayjs from "dayjs";
-import { getCollection } from "astro:content";
 
-const writingEntries = (await getCollection("writing", ({ data }) => !data.draft)).sort(
-  (a, b) => b.data.date.getTime() - a.data.date.getTime()
-);
-const latestWriting = writingEntries.slice(0, 3);
-
-const projectEntries = (await getCollection("projects")).sort(
-  (a, b) => b.data.date.getTime() - a.data.date.getTime()
-);
-const latestProjects = projectEntries.slice(0, 3);
+const currentYear = new Date().getFullYear();
 ---
 
-<AppShell>
+<AppShell hideNavigation>
   <SEO
     slot="head"
-    title="Ashton Hawkins · Builder, designer, and systems thinker"
-    description="Creative technologist building thoughtful products across web, AI, and live experiences."
+    title="Ashton Hawkins · Coming Soon"
+    description="A new digital home for Ashton Hawkins is on the way."
     ogTitle="Ashton Hawkins"
   />
-  <section class="grid gap-16">
-    <div class="with-grain relative overflow-hidden rounded-[32px] border border-border/60 bg-surface/60 p-10 shadow-soft">
-      <div aria-hidden="true" class="pointer-events-none absolute inset-0 overflow-hidden">
-        <div
-          class="bg-radial absolute inset-0"
-          style="
-            --radial-position-x: 20%;
-            --radial-position-y: 25%;
-            --radial-stops: color-mix(in srgb, var(--accent) 28%, transparent) 0%, transparent 70%;
-          "
-        ></div>
-        <div
-          class="bg-conic absolute inset-[10%] mix-blend-screen opacity-70"
-          style="
-            --conic-angle: -140deg;
-            --conic-position-x: 72%;
-            --conic-position-y: 38%;
-            --conic-stops: transparent 0deg,
-              color-mix(in srgb, var(--accent-strong, var(--accent)) 55%, transparent) 120deg,
-              transparent 320deg;
-          "
-        ></div>
-      </div>
-      <div class="relative grid gap-10 md:grid-cols-[1.2fr,1fr]">
-        <div class="space-y-6">
-          <p class="text-sm uppercase tracking-[0.3em] text-text-muted">Hello, I’m Ashton</p>
-          <h1 class="text-4xl font-semibold leading-tight md:text-5xl" data-hero-animate>
-            I design and build delightful software, orchestration systems, and creative tools.
-          </h1>
-          <p class="max-w-prose text-lg text-text-secondary">
-            Currently shipping at the intersection of product, engineering, and storytelling. I craft
-            experiences that feel alive—fast, tactile, and welcoming. This site documents the work,
-            experiments, and ideas along the way.
-          </p>
-          <div class="flex flex-wrap gap-3 text-sm" data-hero-animate>
-            <a
-              href="/projects"
-              class="rounded-full border border-border bg-background px-5 py-2 font-medium text-text-primary transition hover:border-accent hover:bg-accent-soft hover:text-accent"
-              data-astro-transition="animate"
-            >
-              <span class="text-reveal" style="--text-reveal-base: var(--text-1)">Explore projects</span>
-            </a>
-            <a
-              href="/writing"
-              class="rounded-full border border-border/70 px-5 py-2 font-medium text-text-secondary transition hover:border-accent hover:text-text-primary"
-              data-astro-transition="animate"
-            >
-              Read the latest writing
-            </a>
-          </div>
-        </div>
-        <div class="flex h-full flex-col justify-between gap-6">
-          <NowCard />
-          <a
-            href="/now"
-            class="inline-flex items-center gap-2 self-start rounded-full bg-accent text-sm font-semibold text-text-inverted transition hover:bg-accent-strong"
-            data-astro-transition="animate"
-          >
-            <span class="px-4 py-2">Read the full now page</span>
-          </a>
-        </div>
-      </div>
-    </div>
-
-    <section class="grid gap-12 md:grid-cols-[2fr,1.2fr]">
-      <div class="space-y-6">
-        <header class="flex items-center justify-between">
-          <h2 class="text-2xl font-semibold">Latest writing</h2>
-          <a href="/writing" class="text-sm text-text-muted transition hover:text-accent" data-astro-transition="animate">
-            View all
-          </a>
-        </header>
-        <div class="grid gap-5">
-          {latestWriting.length ? (
-            latestWriting.map((entry) => (
-              <article
-                class="group rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-soft transition hover:-translate-y-1 hover:border-accent"
-              >
-                <a
-                  href={`/writing/${entry.slug}`}
-                  class="grid gap-3"
-                  data-astro-transition="animate"
-                >
-                  <span class="text-xs uppercase tracking-[0.3em] text-text-muted">
-                    {dayjs(entry.data.date).format("MMM D, YYYY")}
-                  </span>
-                  <h3 class="text-xl font-semibold">{entry.data.title}</h3>
-                  <p class="text-sm text-text-secondary">{entry.data.summary}</p>
-                  {entry.data.tags.length ? (
-                    <div class="flex flex-wrap gap-2">
-                      {entry.data.tags.map((tag) => (
-                        <span class="rounded-full bg-accent-soft px-3 py-1 text-xs font-medium text-accent" aria-label={`Tagged ${tag}`}>
-                          #{tag}
-                        </span>
-                      ))}
-                    </div>
-                  ) : null}
-                </a>
-              </article>
-            ))
-          ) : (
-            <p class="text-sm text-text-muted">Writing is brewing. Check back soon!</p>
-          )}
-        </div>
-      </div>
-      <div class="space-y-6">
-        <header class="flex items-center justify-between">
-          <h2 class="text-2xl font-semibold">Projects in motion</h2>
-          <a href="/projects" class="text-sm text-text-muted transition hover:text-accent" data-astro-transition="animate">
-            View all
-          </a>
-        </header>
-        <div class="grid gap-5">
-          {latestProjects.length ? (
-            latestProjects.map((entry) => (
-              <article
-                class="group rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-soft transition hover:-translate-y-1 hover:border-accent"
-              >
-                <a
-                  href={`/projects/${entry.slug}`}
-                  class="grid gap-4"
-                  data-astro-transition="animate"
-                >
-                  <div class="flex items-start justify-between">
-                    <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-border/40 text-2xl">
-                      {entry.data.coverEmoji}
-                    </span>
-                    <span class="text-xs uppercase tracking-[0.3em] text-text-muted">
-                      {dayjs(entry.data.date).format("MMM YYYY")}
-                    </span>
-                  </div>
-                  <div class="space-y-2">
-                    <h3 class="text-xl font-semibold">{entry.data.title}</h3>
-                    <p class="text-sm text-text-secondary">{entry.data.summary}</p>
-                    <div class="rounded-2xl bg-background/60 px-4 py-2 text-xs text-text-secondary">
-                      <span class="font-semibold text-text-primary">Role:</span> {entry.data.role}
-                    </div>
-                  </div>
-                  {entry.data.stack.length ? (
-                    <div class="flex flex-wrap gap-2 text-xs text-text-muted">
-                      {entry.data.stack.map((tech) => (
-                        <span class="rounded-full bg-border/40 px-3 py-1 font-medium">{tech}</span>
-                      ))}
-                    </div>
-                  ) : null}
-                  {entry.data.impact.length ? (
-                    <p class="text-xs text-text-muted">
-                      {entry.data.impact[0]}
-                    </p>
-                  ) : null}
-                </a>
-              </article>
-            ))
-          ) : (
-            <p class="text-sm text-text-muted">Projects are being archived. More soon.</p>
-          )}
-        </div>
-      </div>
-    </section>
-  </section>
-  <script type="module" is:inline>
-    import { animate, stagger } from "motion";
-
-    const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)");
-    let hasPlayed = false;
-
-    const playHeroAnimation = () => {
-      if (prefersReduced.matches || hasPlayed) return;
-      const targets = Array.from(document.querySelectorAll("[data-hero-animate]"));
-      if (!targets.length) return;
-
-      animate(
-        targets,
-        { opacity: [0, 1], transform: ["translateY(24px)", "translateY(0)"] },
-        {
-          duration: 0.9,
-          delay: stagger(0.12),
-          easing: "cubic-bezier(0.22, 1, 0.36, 1)",
-          fill: "both"
-        }
-      );
-
-      hasPlayed = true;
-    };
-
-    const scheduleAnimation = () => {
-      hasPlayed = false;
-      if (prefersReduced.matches) return;
-      requestAnimationFrame(() => playHeroAnimation());
-    };
-
-    if (document.readyState !== "loading") {
-      scheduleAnimation();
-    } else {
-      document.addEventListener(
-        "DOMContentLoaded",
-        () => {
-          scheduleAnimation();
-        },
-        { once: true }
-      );
-    }
-
-    document.addEventListener("astro:after-swap", () => {
-      scheduleAnimation();
-    });
-
-    prefersReduced.addEventListener("change", (event) => {
-      if (!event.matches) {
-        scheduleAnimation();
-      }
-    });
-  </script>
+  <main class="flex min-h-[70vh] flex-col items-center justify-center gap-8 text-center">
+    <span class="text-sm uppercase tracking-[0.3em] text-text-muted">Site update in progress</span>
+    <h1 class="max-w-3xl text-balance text-4xl font-semibold leading-tight md:text-5xl">
+      Something new is on the way.
+    </h1>
+    <p class="max-w-xl text-lg text-text-secondary">
+      I’m crafting a refreshed space to share projects, process, and experiments. Check back soon for the
+      full experience—or reach out if you’d like to collaborate in the meantime.
+    </p>
+    <a
+      class="rounded-full border border-border bg-background px-6 py-3 text-sm font-medium text-text-primary transition hover:border-accent hover:bg-accent-soft hover:text-accent"
+      href="mailto:hello@ashtonhawkins.com"
+    >
+      Say hello
+    </a>
+  </main>
+  <footer class="pb-16 text-center text-xs text-text-muted">
+    © {currentYear} Ashton Hawkins. All rights reserved.
+  </footer>
 </AppShell>


### PR DESCRIPTION
## Summary
- replace the existing homepage with a focused “Coming Soon” layout
- provide a brief description, contact link, and footer while the full site is rebuilt
- add a layout option to hide the main navigation and apply it to the placeholder homepage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1b567cf98832c8d03fbcea7121a66