### PR TITLE
Hide search components on coming soon homepage

### DIFF
--- a/src/layouts/AppShell.astro
+++ b/src/layouts/AppShell.astro
@@ -7,6 +7,7 @@ import lenisScript from "../scripts/lenis.ts?url";
 
 interface Props {
   hideNavigation?: boolean;
+  hideSearch?: boolean;
 }
 
 const navLinks = [
@@ -20,7 +21,7 @@ const navLinks = [
   { href: "/activity", label: "Activity" }
 ];
 
-const { hideNavigation = false } = Astro.props as Props;
+const { hideNavigation = false, hideSearch = false } = Astro.props as Props;
 ---
 
 <!DOCTYPE html>
@@ -38,7 +39,7 @@ const { hideNavigation = false } = Astro.props as Props;
     </script>
   </head>
   <body class="min-h-screen bg-background text-text-primary">
-    <CommandPalette client:idle />
+    {!hideSearch && <CommandPalette client:idle />}
     <a
       href="#main"
       class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[9999] focus:rounded-full focus:bg-surface focus:px-4 focus:py-2 focus:text-sm focus:shadow-ring"
@@ -69,14 +70,16 @@ const { hideNavigation = false } = Astro.props as Props;
           </nav>
         )}
         <div class="flex items-center gap-2">
-          <button
-            type="button"
-            class="hidden rounded-full border border-border bg-surface px-4 py-2 text-sm font-medium text-text-secondary shadow-soft transition hover:border-accent hover:text-text-primary hover:shadow-ring md:inline-flex"
-            data-command-button
-          >
-            <span class="hidden lg:inline">Search ·</span>
-            <span class="ml-1 rounded-full bg-accent-soft px-2 py-0.5 text-xs font-semibold text-accent">⌘K</span>
-          </button>
+          {!hideSearch && (
+            <button
+              type="button"
+              class="hidden rounded-full border border-border bg-surface px-4 py-2 text-sm font-medium text-text-secondary shadow-soft transition hover:border-accent hover:text-text-primary hover:shadow-ring md:inline-flex"
+              data-command-button
+            >
+              <span class="hidden lg:inline">Search ·</span>
+              <span class="ml-1 rounded-full bg-accent-soft px-2 py-0.5 text-xs font-semibold text-accent">⌘K</span>
+            </button>
+          )}
           <ThemeToggle client:idle />
         </div>
       </div>
@@ -95,59 +98,63 @@ const { hideNavigation = false } = Astro.props as Props;
             © {new Date().getFullYear()} Ashton Hawkins. All rights reserved.
           </p>
         </div>
-        <div class="w-full max-w-md space-y-4">
-          <h2 class="text-sm font-semibold uppercase tracking-wide text-text-secondary">
-            Search the site
-          </h2>
-          <SearchBox id="footer-search" />
-        </div>
+        {!hideSearch && (
+          <div class="w-full max-w-md space-y-4">
+            <h2 class="text-sm font-semibold uppercase tracking-wide text-text-secondary">
+              Search the site
+            </h2>
+            <SearchBox id="footer-search" />
+          </div>
+        )}
       </div>
     </footer>
-    <script is:inline>
-      const attachCommandButton = () => {
-        const commandButton = document.querySelector('[data-command-button]');
-        if (!commandButton || commandButton.dataset.bound === 'true') return;
-        commandButton.dataset.bound = 'true';
-        commandButton.addEventListener('click', () => {
-          window.dispatchEvent(new CustomEvent('command-palette:open'));
-        });
-      };
-
-      const bindCommandPaletteShortcut = () => {
-        if (window.__commandPaletteShortcutBound) return;
-
-        const handleShortcut = (event) => {
-          if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
-            event.preventDefault();
-            window.dispatchEvent(new CustomEvent('command-palette:toggle'));
-          }
-
-          if (event.key === 'Escape') {
-            window.dispatchEvent(new CustomEvent('command-palette:close'));
-          }
+    {!hideSearch && (
+      <script is:inline>
+        const attachCommandButton = () => {
+          const commandButton = document.querySelector('[data-command-button]');
+          if (!commandButton || commandButton.dataset.bound === 'true') return;
+          commandButton.dataset.bound = 'true';
+          commandButton.addEventListener('click', () => {
+            window.dispatchEvent(new CustomEvent('command-palette:open'));
+          });
         };
 
-        window.addEventListener('keydown', handleShortcut);
-        window.__commandPaletteShortcutBound = true;
+        const bindCommandPaletteShortcut = () => {
+          if (window.__commandPaletteShortcutBound) return;
 
-        document.addEventListener(
-          'astro:before-swap',
-          () => {
-            window.removeEventListener('keydown', handleShortcut);
-            window.__commandPaletteShortcutBound = false;
-          },
-          { once: true }
-        );
-      };
+          const handleShortcut = (event) => {
+            if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+              event.preventDefault();
+              window.dispatchEvent(new CustomEvent('command-palette:toggle'));
+            }
 
-      const initCommandPalette = () => {
-        attachCommandButton();
-        bindCommandPaletteShortcut();
-      };
+            if (event.key === 'Escape') {
+              window.dispatchEvent(new CustomEvent('command-palette:close'));
+            }
+          };
 
-      initCommandPalette();
-      document.addEventListener('astro:page-load', initCommandPalette);
-    </script>
+          window.addEventListener('keydown', handleShortcut);
+          window.__commandPaletteShortcutBound = true;
+
+          document.addEventListener(
+            'astro:before-swap',
+            () => {
+              window.removeEventListener('keydown', handleShortcut);
+              window.__commandPaletteShortcutBound = false;
+            },
+            { once: true }
+          );
+        };
+
+        const initCommandPalette = () => {
+          attachCommandButton();
+          bindCommandPaletteShortcut();
+        };
+
+        initCommandPalette();
+        document.addEventListener('astro:page-load', initCommandPalette);
+      </script>
+    )}
     <script type="module" src={lenisScript}></script>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,7 @@ import SEO from "../components/SEO.astro";
 const currentYear = new Date().getFullYear();
 ---
 
-<AppShell hideNavigation>
+<AppShell hideNavigation hideSearch>
   <SEO
     slot="head"
     title="Ashton Hawkins · Coming Soon"


### PR DESCRIPTION
## Summary
- add a configurable flag to AppShell so the search UI and command palette can be disabled when needed
- hide the search controls on the coming soon homepage while leaving them available elsewhere

## Testing
- npm run lint *(fails: existing lint errors in scripts/aggregate.ts, src/components/SEO.astro, and src/pages/resume.astro)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b993c5cc832ca5a620369c5b189d