### PR TITLE
Redesign Listening nucleus slide into layered, data-rich, genre-reactive canvas renderer

### DIFF
--- a/src/components/home/nucleus/slides/genre-color-map.ts
+++ b/src/components/home/nucleus/slides/genre-color-map.ts
@@ -1,0 +1,48 @@
+export type GenrePalette = { primary: string; secondary: string };
+
+export const GENRE_COLOR_MAP: Record<string, GenrePalette> = {
+  'new wave': { primary: '#8B5CF6', secondary: '#06B6D4' },
+  'synth-pop': { primary: '#8B5CF6', secondary: '#06B6D4' },
+  'post-punk': { primary: '#312E81', secondary: '#991B1B' },
+  darkwave: { primary: '#312E81', secondary: '#991B1B' },
+  rock: { primary: '#D97706', secondary: '#1F2937' },
+  alternative: { primary: '#D97706', secondary: '#1F2937' },
+  electronic: { primary: '#10B981', secondary: '#1D4ED8' },
+  house: { primary: '#10B981', secondary: '#1D4ED8' },
+  'hip-hop': { primary: '#F59E0B', secondary: '#DB2777' },
+  rap: { primary: '#F59E0B', secondary: '#DB2777' },
+  'r&b': { primary: '#F59E0B', secondary: '#DB2777' },
+  jazz: { primary: '#B8860B', secondary: '#1E3A5F' },
+  classical: { primary: '#FFFBEB', secondary: '#7F1D1D' },
+  folk: { primary: '#065F46', secondary: '#92400E' },
+  acoustic: { primary: '#065F46', secondary: '#92400E' },
+  ambient: { primary: '#0D9488', secondary: '#6B7280' },
+  experimental: { primary: '#0D9488', secondary: '#6B7280' },
+  pop: { primary: '#EC4899', secondary: '#3B82F6' },
+  romance: { primary: '#FF2D6B', secondary: '#3B82F6' },
+  drama: { primary: '#2D5BFF', secondary: '#1E293B' },
+  thriller: { primary: '#FF8C00', secondary: '#312E81' },
+  comedy: { primary: '#FFD700', secondary: '#EA580C' },
+  horror: { primary: '#00FF41', secondary: '#111827' },
+  'sci-fi': { primary: '#00FFFF', secondary: '#7C3AED' },
+  scifi: { primary: '#00FFFF', secondary: '#7C3AED' },
+  action: { primary: '#FF0000', secondary: '#991B1B' },
+  documentary: { primary: '#C4A882', secondary: '#334155' },
+  mystery: { primary: '#A24BFF', secondary: '#1E293B' },
+  fantasy: { primary: '#4d9cff', secondary: '#0EA5E9' },
+  animation: { primary: '#ff5fb2', secondary: '#6366F1' },
+  crime: { primary: '#f25f5c', secondary: '#1F2937' },
+};
+
+const normalize = (value: string): string => value.toLowerCase().trim();
+
+export const resolveGenrePalette = (genres: string[], fallback = '#74c6ff'): GenrePalette => {
+  for (const genre of genres) {
+    const normalized = normalize(genre);
+    const exact = GENRE_COLOR_MAP[normalized];
+    if (exact) return exact;
+    const partial = Object.entries(GENRE_COLOR_MAP).find(([key]) => normalized.includes(key));
+    if (partial) return partial[1];
+  }
+  return { primary: fallback, secondary: '#334155' };
+};

--- a/src/components/home/nucleus/slides/watching.ts
+++ b/src/components/home/nucleus/slides/watching.ts
@@ -1,4 +1,5 @@
 import type { SlideData, SlideModule } from '../types';
+import { resolveGenrePalette } from './genre-color-map';
 
 export interface RecentWatch {
   title: string;
@@ -36,21 +37,6 @@ export interface WatchingRenderData {
 const TAU = Math.PI * 2;
 const MONO = '"IBM Plex Mono", monospace';
 
-const GENRE_COLORS: Record<string, string> = {
-  romance: '#FF2D6B',
-  drama: '#2D5BFF',
-  thriller: '#FF8C00',
-  comedy: '#FFD700',
-  horror: '#00FF41',
-  'sci-fi': '#00FFFF',
-  scifi: '#00FFFF',
-  action: '#FF0000',
-  documentary: '#C4A882',
-  mystery: '#A24BFF',
-  fantasy: '#4d9cff',
-  animation: '#ff5fb2',
-  crime: '#f25f5c'
-};
 
 let introStartFrame = 0;
 let frameInitialized = false;
@@ -96,10 +82,8 @@ const ensurePoster = (url?: string | null) => {
 };
 
 const getGenrePalette = (genres: string[], fallback: string): string[] => {
-  const mapped = genres
-    .map((g) => GENRE_COLORS[g.toLowerCase()] ?? null)
-    .filter((g): g is string => Boolean(g));
-  return mapped.length ? mapped : [fallback, '#3d7090'];
+  const palette = resolveGenrePalette(genres, fallback);
+  return [palette.primary, palette.secondary];
 };
 
 const getPrimaryGenreColor = (genres: string[], fallback: string): string => getGenrePalette(genres, fallback)[0] ?? fallback;


### PR DESCRIPTION
### Motivation
- Replace the existing stretched “now playing” card with a cinematic, data-driven listening slide that treats music as a temporal, rhythmic data stream rather than a static widget. 
- Surface deeper Last.fm telemetry (plays, loved, recent timeline, top artists, streaks) and use mood/BPM to drive animation tempo and atmosphere.
- Unify genre color logic across slides by centralizing the genre → palette mapping for consistent visual language.

### Description
- Reimplemented the Listening nucleus slide as a layered canvas renderer with genre/mood-reactive atmosphere, BPM pulse, duotone album-art treatment (duotone + scanlines + glow + reflection), animated frequency bars, timeline, and a bottom stats dashboard; main implementation in `src/components/home/nucleus/slides/listening.ts`.
- Expanded Last.fm utilities in `src/lib/lastfm.ts` to fetch richer context: `getRecentTracks`, `getUserTopArtists`, `getUserInfo`, per-track `userplaycount`/`userloved` and `loved` flags, and conservative BPM estimation; interfaces updated to carry the new fields.
- Added a shared genre color map and resolver (`src/components/home/nucleus/slides/genre-color-map.ts`) and updated the Watching slide to use the same resolver so palettes are centralized and consistent across slides.
- Data merge/fallback logic was updated so the slide composes Last.fm + optional Spotify mood/features, derives weekly/all-time stats, listening streak and avg/day, and gracefully degrades when optional fields or album art are missing.
- Kept animations/config pattern compatible with existing nucleus engine (entry/exit lifecycle via `fetchData` / `render` / `reset`) and implemented the visualization using canvas primitives for performant visuals tied to BPM/energy.

### Testing
- Ran `npm run check` (Astro type/content checks) and there were 0 errors (some existing hints only). (Succeeded)
- Launched the local dev server with `npm run dev -- --host 0.0.0.0 --port 4321` and visually inspected the redesign in the running app. (Succeeded)
- Captured a Playwright screenshot of the homepage to validate the updated Listening slide rendering via an automated script (screenshot artifact produced). (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f37159574832ca785a0c1ed60af26)